### PR TITLE
android: stricten mimetypes app accepts from */* to application/octet-stream

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="*/*" android:scheme="content"/>
+                <data android:mimeType="application/octet-stream" android:scheme="content"/>
             </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Apparently some users have an issue with the app being incorrectly used for opening certain types, like PDFs.

https://discord.com/channels/221364737269694464/221364737269694464/1507412822324412446

This strictens the accepted content types. We could drop this line fully and rely on the filter lines above for pbw, pbz, pbl, but it might break opens from situations where real filename aren't reported.