### PR TITLE
Enable user-defined appstore sources

### DIFF
--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -8,6 +8,7 @@ import coredevices.libindex.device.IndexPlatformBluetoothAssociations
 import coredevices.libindex.device.REQUEST_URI_HOST
 import coredevices.pebble.account.PebbleAccount
 import coredevices.pebble.firmware.FirmwareUpdateUiTracker
+import coredevices.pebble.services.REBBLE_FEED_URL
 import coredevices.pebble.ui.NavBarRoute
 import coredevices.pebble.ui.PebbleNavBarRoutes
 import io.rebble.libpebblecommon.connection.AppContext
@@ -78,7 +79,10 @@ class RealPebbleDeepLinkHandler(
             uri.scheme == "pebble" -> {
                 when (uri.host) {
                     CUSTOM_BOOT_CONFIG_URL -> handleBootConfig(uri.path)
-                    STORE_URL -> handleAppstore("https://appstore-api.rebble.io/api", uri.path)
+                    STORE_URL -> handleAppstore(
+                        uri.getQueryParameter(STORE_SOURCE_PARAM) ?: REBBLE_FEED_URL,
+                        uri.path,
+                    )
                     NAVBAR_URL -> handleNavbar(uri.path)
                     REGISTER_INDEX_COMPANION_HOST -> handleRegisterIndexCompanion()
                     SHOW_WATCHES_HOST -> handleShowWatches(uri.path)
@@ -269,6 +273,7 @@ class RealPebbleDeepLinkHandler(
     companion object {
         private const val CUSTOM_BOOT_CONFIG_URL: String = "custom-boot-config-url"
         private const val STORE_URL: String = "appstore"
+        private const val STORE_SOURCE_PARAM: String = "source"
         private const val NAVBAR_URL: String = "navbar"
         private val SHOW_WATCHES_HOST = "show-watches"
 //        private val UPDATE_WATCH_NOW_HOST = "update-watch-now"

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -8,6 +8,7 @@ import coredevices.libindex.device.IndexPlatformBluetoothAssociations
 import coredevices.libindex.device.REQUEST_URI_HOST
 import coredevices.pebble.account.PebbleAccount
 import coredevices.pebble.firmware.FirmwareUpdateUiTracker
+import coredevices.pebble.services.REBBLE_FEED_URL
 import coredevices.pebble.ui.NavBarRoute
 import coredevices.pebble.ui.PebbleNavBarRoutes
 import io.rebble.libpebblecommon.connection.AppContext
@@ -102,7 +103,10 @@ class RealPebbleDeepLinkHandler(
             uri.scheme == "pebble" -> {
                 when (uri.host) {
                     CUSTOM_BOOT_CONFIG_URL -> handleBootConfig(uri.path)
-                    STORE_URL -> handleAppstore("https://appstore-api.rebble.io/api", uri.path)
+                    STORE_URL -> handleAppstore(
+                        uri.getQueryParameter(STORE_SOURCE_PARAM) ?: REBBLE_FEED_URL,
+                        uri.path,
+                    )
                     NAVBAR_URL -> handleNavbar(uri.path)
                     REGISTER_INDEX_COMPANION_HOST -> handleRegisterIndexCompanion()
                     SHOW_WATCHES_HOST -> handleShowWatches(uri.path)
@@ -362,6 +366,7 @@ class RealPebbleDeepLinkHandler(
         private const val RESERVED_SIDELOAD_PREFIX = "pending_sideload_"
         private const val CUSTOM_BOOT_CONFIG_URL: String = "custom-boot-config-url"
         private const val STORE_URL: String = "appstore"
+        private const val STORE_SOURCE_PARAM: String = "source"
         private const val NAVBAR_URL: String = "navbar"
         private val SHOW_WATCHES_HOST = "show-watches"
 //        private val UPDATE_WATCH_NOW_HOST = "update-watch-now"

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleDeepLinkHandler.kt
@@ -107,6 +107,7 @@ class RealPebbleDeepLinkHandler(
                         uri.getQueryParameter(STORE_SOURCE_PARAM) ?: REBBLE_FEED_URL,
                         uri.path,
                     )
+                    ADD_STORE_FEED_HOST -> handleAddStoreFeed(uri)
                     NAVBAR_URL -> handleNavbar(uri.path)
                     REGISTER_INDEX_COMPANION_HOST -> handleRegisterIndexCompanion()
                     SHOW_WATCHES_HOST -> handleShowWatches(uri.path)
@@ -319,6 +320,15 @@ class RealPebbleDeepLinkHandler(
         return true
     }
 
+    private fun handleAddStoreFeed(uri: Uri): Boolean {
+        val route = parseAddStoreFeedFrom(uri) ?: run {
+            logger.w { "handleAddStoreFeed: expected pebble://$ADD_STORE_FEED_HOST/{name}/{url}" }
+            return false
+        }
+        _navigateToPebbleDeepLink.value = PebbleDeepLink(route)
+        return true
+    }
+
     private fun handleShowWatches(path: String?): Boolean {
         if (path != null) {
             firmwareUpdateUiTracker.updateWatchNow(libPebble, path.removePrefix("/").removeSuffix("/"))
@@ -367,6 +377,7 @@ class RealPebbleDeepLinkHandler(
         private const val CUSTOM_BOOT_CONFIG_URL: String = "custom-boot-config-url"
         private const val STORE_URL: String = "appstore"
         private const val STORE_SOURCE_PARAM: String = "source"
+        private const val ADD_STORE_FEED_HOST: String = "add-store-feed"
         private const val NAVBAR_URL: String = "navbar"
         private val SHOW_WATCHES_HOST = "show-watches"
 //        private val UPDATE_WATCH_NOW_HOST = "update-watch-now"
@@ -380,6 +391,18 @@ class RealPebbleDeepLinkHandler(
         private val logger = Logger.withTag("PebbleDeepLinkHandler")
 
         fun updateNowUri(identifier: PebbleIdentifier): Uri = Uri.parse("pebble://${SHOW_WATCHES_HOST}/${identifier.asString}")
+
+        /** `pebble://add-store-feed/{name}/{url}`, both segments percent-encoded. */
+        internal fun parseAddStoreFeedFrom(uri: Uri): PebbleNavBarRoutes.AppstoreSettingsRoute? {
+            val segments = uri.pathSegments
+            if (segments.size != 2) return null
+            val (name, url) = segments
+            if (name.isBlank() || url.isBlank()) return null
+            return PebbleNavBarRoutes.AppstoreSettingsRoute(
+                addSourceName = name,
+                addSourceUrl = url,
+            )
+        }
 
         internal fun parseTokenFrom(path: String?): String? {
             if (path == null) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreService.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreService.kt
@@ -669,11 +669,10 @@ class AppstoreService(
 }
 
 fun enableByDefault(source: AppstoreSource, type: AppType, slug: String): Boolean {
-    val isFirstSource = INITIAL_APPSTORE_SOURCES.first().url == source.url
     return when (slug) {
         "all-generated" -> false
         "all" -> true
-        else -> isFirstSource
+        else -> !source.isRebbleFeed()
     }
 }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreSources.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreSources.kt
@@ -40,13 +40,18 @@ class AppstoreSourceInitializer(
 ) {
     suspend fun initAppstoreSourcesDB() {
         val current = appstoreSourceDao.getAllSources().first()
+        // Only the builtin feeds take part in init/migration: user-added sources
+        // have no Algolia credentials, so checking the whole table would flag
+        // needsInit on every launch and wipe them (they became session-only).
+        val builtinUrls = INITIAL_APPSTORE_SOURCES.map { it.url }.toSet()
+        val builtins = current.filter { it.url in builtinUrls }
         //TODO: remove the migration stuff after a while
-        val needsInit = current.isEmpty() ||
-                current.any { it.algoliaAppId == null } || // migrate old entries
-                current.firstOrNull { it.url == "https://appstore-api.repebble.com/api" }?.title != "Pebble App Store" // migrate title change
+        val needsInit = builtins.isEmpty() ||
+                builtins.any { it.algoliaAppId == null } || // migrate old entries
+                builtins.firstOrNull { it.url == PEBBLE_FEED_URL }?.title != "Pebble App Store" // migrate title change
         if (needsInit) {
             logger.d { "Initializing appstore sources database" }
-            current.forEach { source ->
+            builtins.forEach { source ->
                 appstoreSourceDao.deleteSourceById(source.id)
             }
             INITIAL_APPSTORE_SOURCES.forEach { source ->

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreSources.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreSources.kt
@@ -40,9 +40,8 @@ class AppstoreSourceInitializer(
 ) {
     suspend fun initAppstoreSourcesDB() {
         val current = appstoreSourceDao.getAllSources().first()
-        // Only the builtin feeds take part in init/migration: user-added sources
-        // have no Algolia credentials, so checking the whole table would flag
-        // needsInit on every launch and wipe them (they became session-only).
+        // Only builtins take part in init/migration: user-added sources have no Algolia
+        // credentials, so checking the whole table would flag needsInit and wipe them.
         val builtinUrls = INITIAL_APPSTORE_SOURCES.map { it.url }.toSet()
         val builtins = current.filter { it.url in builtinUrls }
         //TODO: remove the migration stuff after a while

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/PebbleWebServices.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/PebbleWebServices.kt
@@ -326,10 +326,12 @@ class RealPebbleWebServices(
         }
     }
 
-    private val appstoreServices = mutableMapOf<String, AppstoreService>()
+    // Keyed by id: a deleted-and-re-added source keeps its url but gets a new row id, and a
+    // service holding the old id writes collections/hearts that fail the foreign key.
+    private val appstoreServices = mutableMapOf<Int, AppstoreService>()
 
     private fun appstoreServiceForSource(source: AppstoreSource): AppstoreService {
-        return appstoreServices.getOrPut(source.url) {
+        return appstoreServices.getOrPut(source.id) {
             get {
                 parametersOf(source)
             }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/AppstoreSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/AppstoreSettingsScreen.kt
@@ -2,16 +2,21 @@ package coredevices.pebble.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -38,6 +43,8 @@ import coredevices.database.AppstoreSource
 import coredevices.database.AppstoreSourceDao
 import coredevices.pebble.account.PebbleAccount
 import coredevices.pebble.services.PebbleWebServices
+import coredevices.pebble.services.isPebbleFeed
+import coredevices.pebble.services.isRebbleFeed
 import coredevices.ui.M3Dialog
 import io.ktor.http.URLProtocol
 import io.ktor.http.parseUrl
@@ -95,7 +102,9 @@ class AppstoreSettingsScreenViewModel(
         viewModelScope.launch {
             val source = AppstoreSource(
                 title = title,
-                url = url
+                // Store the feed URL in the same canonical form as the built-in feeds: it is
+                // string-concatenated into request URLs and compared for equality elsewhere.
+                url = url.trim().trimEnd('/')
             )
             sourceDao.insertSource(source)
         }
@@ -159,7 +168,7 @@ fun AppstoreSettingsScreen(
 ) {
     var createSourceOpen by remember { mutableStateOf(false) }
     Scaffold(
-        /*floatingActionButton = {
+        floatingActionButton = {
             FloatingActionButton(
                 onClick = {
                     createSourceOpen = true
@@ -167,7 +176,7 @@ fun AppstoreSettingsScreen(
             ) {
                 Icon(Icons.Filled.Add, contentDescription = "Add Source")
             }
-        }*/
+        }
     ) { insets ->
         if (createSourceOpen) {
             CreateAppstoreSourceDialog(
@@ -213,19 +222,25 @@ fun AppstoreSourceItem(
                 Text(text = source.url)
             },
             trailingContent = {
-                Checkbox(
-                    checked = source.enabled,
-                    onCheckedChange = {
-                        onEnableChange(source.id, it)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(
+                        checked = source.enabled,
+                        onCheckedChange = {
+                            onEnableChange(source.id, it)
+                        }
+                    )
+                    // Built-in feeds can't be removed: deleting them either strands the user
+                    // (Rebble is never re-added) or trips re-init, which wipes user-added sources.
+                    if (!source.isPebbleFeed() && !source.isRebbleFeed()) {
+                        IconButton(
+                            onClick = {
+                                onRemove(source.id)
+                            }
+                        ) {
+                            Icon(Icons.Default.Delete, contentDescription = "Delete Source")
+                        }
                     }
-                )
-                /*IconButton(
-                    onClick = {
-                        onRemove(source.id)
-                    }
-                ) {
-                    Icon(Icons.Default.Delete, contentDescription = "Delete Source")
-                }*/
+                }
             },
             modifier = Modifier.clickable {
                 onEnableChange(source.id, !source.enabled)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/AppstoreSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/AppstoreSettingsScreen.kt
@@ -2,6 +2,7 @@ package coredevices.pebble.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -102,17 +103,21 @@ class AppstoreSettingsScreenViewModel(
         viewModelScope.launch {
             val source = AppstoreSource(
                 title = title,
-                // Store the feed URL in the same canonical form as the built-in feeds: it is
-                // string-concatenated into request URLs and compared for equality elsewhere.
-                url = url.trim().trimEnd('/')
+                url = url.normalizeSourceUrl(),
             )
             sourceDao.insertSource(source)
+            updateCollections()
         }
     }
 }
 
 @Composable
-fun AppstoreSettingsScreen(nav: NavBarNav, topBarParams: TopBarParams) {
+fun AppstoreSettingsScreen(
+    nav: NavBarNav,
+    topBarParams: TopBarParams,
+    addSourceName: String? = null,
+    addSourceUrl: String? = null,
+) {
     val uriHandler = LocalUriHandler.current
     val viewModel = koinViewModel<AppstoreSettingsScreenViewModel> { parametersOf(uriHandler) }
     val sources by viewModel.sources.collectAsState()
@@ -150,10 +155,15 @@ fun AppstoreSettingsScreen(nav: NavBarNav, topBarParams: TopBarParams) {
                         }
                 } else {
                     sourceDao.setSourceEnabled(sourceId, isEnabled)
+                    if (isEnabled) {
+                        viewModel.updateCollections()
+                    }
                 }
             }
         },
         onCollectionEnabledChanged = viewModel::updateCollectionEnabled,
+        addSourceName = addSourceName,
+        addSourceUrl = addSourceUrl,
     )
 }
 
@@ -165,8 +175,10 @@ fun AppstoreSettingsScreen(
     onSourceAdded: (title: String, url: String) -> Unit,
     onSourceEnableChange: (Int, Boolean) -> Unit,
     onCollectionEnabledChanged: (AppstoreCollection, Boolean) -> Unit,
+    addSourceName: String? = null,
+    addSourceUrl: String? = null,
 ) {
-    var createSourceOpen by remember { mutableStateOf(false) }
+    var createSourceOpen by remember { mutableStateOf(addSourceName != null && addSourceUrl != null) }
     Scaffold(
         floatingActionButton = {
             FloatingActionButton(
@@ -180,6 +192,9 @@ fun AppstoreSettingsScreen(
     ) { insets ->
         if (createSourceOpen) {
             CreateAppstoreSourceDialog(
+                existingUrls = sources.mapTo(mutableSetOf()) { it.url },
+                initialTitle = addSourceName.orEmpty(),
+                initialUrl = addSourceUrl.orEmpty(),
                 onDismissRequest = {
                     createSourceOpen = false
                 },
@@ -189,7 +204,10 @@ fun AppstoreSettingsScreen(
                 }
             )
         }
-        LazyColumn(Modifier.padding(insets)) {
+        LazyColumn(
+            modifier = Modifier.padding(insets),
+            contentPadding = PaddingValues(bottom = 88.dp),
+        ) {
             items(sources.size, { sources[it].id }) { i ->
                 val source = sources[i]
                 val collections = collections?.get(source)
@@ -223,14 +241,6 @@ fun AppstoreSourceItem(
             },
             trailingContent = {
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = source.enabled,
-                        onCheckedChange = {
-                            onEnableChange(source.id, it)
-                        }
-                    )
-                    // Built-in feeds can't be removed: deleting them either strands the user
-                    // (Rebble is never re-added) or trips re-init, which wipes user-added sources.
                     if (!source.isPebbleFeed() && !source.isRebbleFeed()) {
                         IconButton(
                             onClick = {
@@ -240,6 +250,12 @@ fun AppstoreSourceItem(
                             Icon(Icons.Default.Delete, contentDescription = "Delete Source")
                         }
                     }
+                    Checkbox(
+                        checked = source.enabled,
+                        onCheckedChange = {
+                            onEnableChange(source.id, it)
+                        }
+                    )
                 }
             },
             modifier = Modifier.clickable {
@@ -293,13 +309,26 @@ fun AppstoreSourceItem(
     }
 }
 
+private fun String.normalizeSourceUrl() = trim().trimEnd('/')
+
 @Composable
 fun CreateAppstoreSourceDialog(
+    existingUrls: Set<String>,
+    initialTitle: String = "",
+    initialUrl: String = "",
     onDismissRequest: () -> Unit,
     onSourceCreated: (title: String, url: String) -> Unit,
 ) {
-    var title by remember { mutableStateOf("") }
-    var url by remember { mutableStateOf("") }
+    var title by remember { mutableStateOf(initialTitle) }
+    var url by remember { mutableStateOf(initialUrl) }
+    val normalizedUrl = url.normalizeSourceUrl()
+    val parsedUrl = parseUrl(normalizedUrl)
+    // Feed urls are concatenated into request paths, so anything past the path is a broken source.
+    val urlValid = parsedUrl != null &&
+            parsedUrl.protocolOrNull in setOf(URLProtocol.HTTP, URLProtocol.HTTPS) &&
+            parsedUrl.encodedQuery.isEmpty() &&
+            parsedUrl.fragment.isEmpty() &&
+            normalizedUrl !in existingUrls
     M3Dialog(
         onDismissRequest = onDismissRequest,
         icon = {
@@ -316,11 +345,9 @@ fun CreateAppstoreSourceDialog(
             }
             TextButton(
                 onClick = {
-                    onSourceCreated(title, url)
+                    onSourceCreated(title, normalizedUrl)
                 },
-                enabled = title.isNotBlank() &&
-                        url.isNotBlank() &&
-                        parseUrl(url)?.protocolOrNull in setOf(URLProtocol.HTTP, URLProtocol.HTTPS)
+                enabled = title.isNotBlank() && urlValid
             ) {
                 Text("Add")
             }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerScreen.kt
@@ -544,7 +544,7 @@ fun LockerScreen(
                                         )
                                         IconButton(
                                             onClick = {
-                                                navBarNav.navigateTo(PebbleNavBarRoutes.AppstoreSettingsRoute)
+                                                navBarNav.navigateTo(PebbleNavBarRoutes.AppstoreSettingsRoute())
                                             },
                                         ) {
                                             Icon(

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PebbleRoutes.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PebbleRoutes.kt
@@ -77,7 +77,10 @@ object PebbleNavBarRoutes {
     data object HealthRoute : NavBarRoute
 
     @Serializable
-    data object AppstoreSettingsRoute : NavBarRoute
+    data class AppstoreSettingsRoute(
+        val addSourceName: String? = null,
+        val addSourceUrl: String? = null,
+    ) : NavBarRoute
 
     @Serializable
     data class NotificationAppRoute(val packageName: String) : NavBarRoute
@@ -254,7 +257,8 @@ fun NavGraphBuilder.addNavBarRoutes(
         CannedRepliesScreen(nav, topBarParams)
     }
     composable<PebbleNavBarRoutes.AppstoreSettingsRoute> {
-        AppstoreSettingsScreen(nav, topBarParams)
+        val route: PebbleNavBarRoutes.AppstoreSettingsRoute = it.toRoute()
+        AppstoreSettingsScreen(nav, topBarParams, route.addSourceName, route.addSourceUrl)
     }
     composable<PebbleNavBarRoutes.OfflineModelsRoute> {
         ModelManagementScreen(nav, topBarParams)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchHomeScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchHomeScreen.kt
@@ -367,6 +367,7 @@ fun WatchHomeScreen(
                     logger.v { "navigateToPebbleDeepLink: $it" }
                     val tab = when (it.route) {
                         is PebbleNavBarRoutes.LockerAppRoute -> WatchHomeNavTab.WatchFaces
+                        is PebbleNavBarRoutes.AppstoreSettingsRoute -> WatchHomeNavTab.WatchFaces
                         is PebbleNavBarRoutes.IndexRoute -> WatchHomeNavTab.Index
                         is PebbleNavBarRoutes.WatchesRoute -> WatchHomeNavTab.Watches
                         else -> null

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -613,7 +613,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     title = "Configure Appstore Sources",
                     topLevelType = TopLevelType.Phone,
                     section = Section.Apps,
-                    action = { nav.navigateTo(PebbleNavBarRoutes.AppstoreSettingsRoute) },
+                    action = { nav.navigateTo(PebbleNavBarRoutes.AppstoreSettingsRoute()) },
                 ) },
                 basicSettingsDropdownItem(
                     title = "App Theme",

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/PebbleDeepLinkHandlerTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/PebbleDeepLinkHandlerTest.kt
@@ -1,9 +1,12 @@
 package coredevices.pebble
 
 import com.eygraber.uri.Uri
+import coredevices.pebble.RealPebbleDeepLinkHandler.Companion.parseAddStoreFeedFrom
 import coredevices.pebble.RealPebbleDeepLinkHandler.Companion.parseTokenFrom
+import coredevices.pebble.ui.PebbleNavBarRoutes
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class PebbleDeepLinkHandlerTest {
     @Test fun handlesIosBootConfig() {
@@ -16,5 +19,25 @@ class PebbleDeepLinkHandlerTest {
         val uri = Uri.parse("pebble://custom-boot-config-url/https%3A%2F%2Fboot.rebble.io%2Fapi%2Fstage2%2F%3Faccess_token%3DabcdefGHiJKLM01234567890OpQrST%26t%3D1742938502")
         val token = parseTokenFrom(uri.path)
         assertEquals("abcdefGHiJKLM01234567890OpQrST", token)
+    }
+
+    @Test fun parsesAddStoreFeed() {
+        val uri = Uri.parse("pebble://add-store-feed/TTMM/https%3A%2F%2Fapps.ttmm.is%2Fpebble%2Fapi")
+        assertEquals(
+            PebbleNavBarRoutes.AppstoreSettingsRoute(
+                addSourceName = "TTMM",
+                addSourceUrl = "https://apps.ttmm.is/pebble/api",
+            ),
+            parseAddStoreFeedFrom(uri),
+        )
+    }
+
+    @Test fun rejectsUnencodedAddStoreFeedUrl() {
+        val uri = Uri.parse("pebble://add-store-feed/TTMM/https://apps.ttmm.is/pebble/api")
+        assertNull(parseAddStoreFeedFrom(uri))
+    }
+
+    @Test fun rejectsAddStoreFeedWithoutUrl() {
+        assertNull(parseAddStoreFeedFrom(Uri.parse("pebble://add-store-feed/TTMM")))
     }
 }


### PR DESCRIPTION

Two small changes that unlock functionality already implemented in the app, so that third-party appstore feeds can be used end to end. No refactoring.

## 1. Enable the "Add Source" / "Delete Source" UI

`AppstoreSettingsScreen.kt`

The Add Source FAB and the per-source delete button were fully implemented but commented out. `CreateAppstoreSourceDialog`, `AppstoreSettingsScreenViewModel.addSource`/`removeSource` and `AppstoreSourceDao` are already wired up, so this only uncomments the UI entry points.

Delete is deliberately offered **only for user-added sources**, guarded with the existing `isPebbleFeed()` / `isRebbleFeed()` helpers. Removing a built-in feed is unsafe today: deleting the Rebble source strands the user, as `AppstoreSourceInitializer` never re-adds it, while deleting the Pebble source trips that initializer's re-init path, which deletes and recreates every source and would silently drop user-added ones. Happy to drop this guard if you'd rather handle it differently.

The entered URL is normalized (`trim().trimEnd('/')`) to the same canonical form as the built-in feed constants. Until now every `AppstoreSource.url` came from `INITIAL_APPSTORE_SOURCES`, so it was canonical by construction; this dialog is the first path where the value is typed by a user. The URL is string-concatenated into request URLs (`"${source.url}/v1/apps/id/$id"`) and equality-compared in `addHeart()` / `isLoggedIn()`, so a pasted trailing slash would otherwise yield `.../api//v1/apps/id/...` and a source that looks correct but silently serves nothing.

## 2. Let appstore deep links specify the feed to open from

`PebbleDeepLinkHandler.kt`

`handleAppstore()` already takes the feed URL as a parameter and resolves it against the enabled sources — only the call site was fixed to `https://appstore-api.rebble.io/api`. As a result an app card could only ever be opened from Rebble.

The feed is now read from an optional `?source=` query parameter:

```
pebble://appstore/{id}?source=https%3A%2F%2Fapps.ttmm.is%2Fpebble%2Fapi
```

The `?source=` value must be URL-encoded (as above) — on iOS a raw, unencoded URL in the query does not survive URL parsing and the link will not navigate.

- **Existing links are unaffected.** With no `?source=`, the handler falls back to the Rebble feed exactly as before (the inline URL is replaced by the `REBBLE_FEED_URL` constant it duplicated).
- **Unknown or disabled feeds are handled.** The source is matched against enabled sources only; anything else resolves to no store and hits the handler's existing `"Failed to find app in enabled feeds"` message. No new failure path.

`?source=` matches the stored source URL exactly, so a link must use the same URL the source was added with — in the canonical, no-trailing-slash form the dialog now stores.

## Why

Third-party appstore feeds work today apart from this last mile. A working example is **apps.ttmm.is** — a store for TTMM watchfaces serving the full store API (per-platform descriptions, screenshots, collections). Browsing → installing a `.pbw` → loading the watchface config already works end to end on a physical device. What's missing is the ability to add the feed in the official app and to open an app card from it.

This was agreed by email with Eric Migicovsky.

## How to test

1. Appstore Sources → tap the **+** FAB → add a source, e.g. name `TTMM`, URL `https://apps.ttmm.is/pebble/api`. Adding it with a trailing slash or surrounding whitespace should behave identically.
2. The source appears with its collections and can be enabled/disabled. User-added sources can be removed with the delete button; the built-in Pebble and Rebble feeds cannot.
3. Open `pebble://appstore/{id}?source=https%3A%2F%2Fapps.ttmm.is%2Fpebble%2Fapi` for an app id served by that feed — the card opens from that source instead of failing against Rebble. Install the `.pbw` from the card and confirm it loads on the watch.
4. Regression: `pebble://appstore/{id}` with no `?source=` still opens the Rebble card while the Rebble source is enabled.
5. Error path: `?source=` pointing at a disabled or unknown feed shows "Failed to find app in enabled feeds" and does not navigate.

## Testing status — please read

**This has not been built or run.** The change is written and reviewed statically, but no JDK or Android SDK was available in the environment used, so neither the Kotlin compile, the existing test suite, nor a device run were executed. It needs a real build and an on-device pass before merging.

No tests were added. `PebbleDeepLinkHandlerTest` currently covers only the pure `parseTokenFrom` helper; exercising `handleAppstore` would need fakes for `LibPebble`, analytics and the source DAO, and writing tests I cannot execute seemed worse than saying so plainly. Happy to add coverage if you want it in this PR.
