### PR TITLE
Implement native Android PebbleBridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 iosApp/iosApp.xcodeproj/xcuserdata
 iosApp/iosApp.xcworkspace/xcuserdata
 iosApp/iosApp/GoogleService-Info.plist
+composeApp/google-services.json

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ play-update = "2.1.0"
 crashkios = "0.9.0"
 androidx-lifecycle = "2.9.6"
 androidx-navigation = "2.9.2"
+androidx-security-crypto = "1.1.0-alpha06"
 firebase-kotlin = "2.4.0"
 # Deliberately ahead of the BOM firebase-kotlin imports (33.15.0): its firebase-auth 23.2.1 has an
 # acknowledged regression that randomly signs users out (firebase-android-sdk#7111). We avoid the
@@ -143,6 +144,7 @@ crashkios = { module = "co.touchlab.crashkios:crashlytics", version.ref = "crash
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-auth = { group = "dev.gitlive", name = "firebase-auth", version.ref = "firebase-kotlin" }
 firebase-firestore = { group = "dev.gitlive", name = "firebase-firestore", version.ref = "firebase-kotlin" }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/LockerWrapper.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/LockerWrapper.kt
@@ -21,6 +21,7 @@ enum class AppCapability(val code: String) {
     Health("health"),
     Location("location"),
     Timeline("timeline"),
+    NetworkBridge("config_network_bridge"),
     // Not included: "configurable" (separate field in database, doesn't require permission grant)
     ;
 

--- a/pebble/build.gradle.kts
+++ b/pebble/build.gradle.kts
@@ -107,6 +107,7 @@ kotlin {
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.contentNegotiation)
                 implementation(libs.ktor.client.serialization.json)
+                implementation(libs.ktor.websockets)
                 implementation(libs.coil)
                 implementation(libs.coil.ktor)
                 implementation(libs.webview)
@@ -139,6 +140,8 @@ kotlin {
                 // commonMain by default and will correctly pull the Android artifacts of any KMP
                 // dependencies declared in commonMain.
                 implementation(compose.uiTooling)
+                implementation(libs.ktor.client.okhttp)
+                implementation(libs.androidx.security.crypto)
             }
         }
 

--- a/pebble/src/androidMain/assets/bridge-shim.js
+++ b/pebble/src/androidMain/assets/bridge-shim.js
@@ -1,0 +1,125 @@
+(function() {
+    if (window.pebbleBridge) return;
+
+    function makeCallback(resolve, reject) {
+        const id = 'cb_' + Math.random().toString(36).slice(2);
+        window.__pebbleBridgeCallbacks = window.__pebbleBridgeCallbacks || {};
+        window.__pebbleBridgeCallbacks[id] = {
+            resolve: function(v) {
+                delete window.__pebbleBridgeCallbacks[id];
+                resolve(v);
+            },
+            reject: function(e) {
+                delete window.__pebbleBridgeCallbacks[id];
+                reject(new Error(e));
+            }
+        };
+        return id;
+    }
+
+    function BridgeResponse(raw) {
+        const data = (typeof raw === 'string') ? JSON.parse(raw) : raw;
+        this.ok = data.ok;
+        this.status = data.status;
+        this.statusText = data.statusText;
+        this.headers = data.headers || {};
+        this._body = data.body || '';
+    }
+    BridgeResponse.prototype.text = function() {
+        return Promise.resolve(typeof this._body === 'string' ? this._body : JSON.stringify(this._body));
+    };
+    BridgeResponse.prototype.json = function() {
+        if (typeof this._body === 'string') {
+            return Promise.resolve(JSON.parse(this._body));
+        }
+        return Promise.resolve(this._body);
+    };
+
+    function BridgeWebSocket(url, protocols) {
+        const self = this;
+        protocols = protocols || [];
+        this.url = url;
+        this.readyState = 0;
+        this.id = 'ws_' + Math.random().toString(36).slice(2);
+        window.__pebbleBridgeWebSockets = window.__pebbleBridgeWebSockets || {};
+        window.__pebbleBridgeWebSockets[this.id] = this;
+        this.onopen = null;
+        this.onmessage = null;
+        this.onerror = null;
+        this.onclose = null;
+
+        // Native bridge emits events by calling these methods on the socket object.
+        this.open = function() {
+            self.readyState = BridgeWebSocket.OPEN;
+            if (self.onopen) self.onopen();
+        };
+        this.message = function(data) {
+            if (self.onmessage) self.onmessage({ data: data });
+        };
+        this.error = function(msg) {
+            if (self.onerror) self.onerror(new Error(msg));
+        };
+        // Native emits close event with {code, reason}; user calls close(code, reason).
+        this.close = function(arg1, arg2) {
+            if (arg1 && typeof arg1 === 'object' && 'code' in arg1) {
+                self.readyState = BridgeWebSocket.CLOSED;
+                if (self.onclose) self.onclose({ code: arg1.code, reason: arg1.reason || '', wasClean: arg1.code === 1000 });
+            } else {
+                self.readyState = BridgeWebSocket.CLOSING;
+                window.PebbleBridgeNative.webSocketClose(self.id, arg1 || 1000, arg2 || '');
+            }
+        };
+
+        window.PebbleBridgeNative.webSocketConnect(this.id, url, JSON.stringify(protocols));
+
+        this.send = function(data) {
+            window.PebbleBridgeNative.webSocketSend(self.id, data);
+        };
+    }
+    BridgeWebSocket.CONNECTING = 0;
+    BridgeWebSocket.OPEN = 1;
+    BridgeWebSocket.CLOSING = 2;
+    BridgeWebSocket.CLOSED = 3;
+
+    window.pebbleBridge = {
+        version: window.PebbleBridgeNative.version(),
+        config: JSON.parse(window.PebbleBridgeNative.getConfig()),
+        fetch: function(url, options) {
+            options = options || {};
+            return new Promise(function(resolve, reject) {
+                const req = {
+                    url: url,
+                    method: options.method || 'GET',
+                    headers: options.headers || {},
+                    body: options.body || null,
+                    timeout: options.timeout || 30000
+                };
+                window.PebbleBridgeNative.fetch(
+                    JSON.stringify(req),
+                    makeCallback(function(raw) { resolve(new BridgeResponse(raw)); }, reject)
+                );
+            });
+        },
+        WebSocket: BridgeWebSocket,
+        storage: {
+            get: function(key) {
+                return new Promise(function(resolve, reject) {
+                    window.PebbleBridgeNative.storageGet(key, makeCallback(resolve, reject));
+                });
+            },
+            set: function(key, value) {
+                return new Promise(function(resolve, reject) {
+                    window.PebbleBridgeNative.storageSet(key, value, makeCallback(resolve, reject));
+                });
+            },
+            remove: function(key) {
+                return new Promise(function(resolve, reject) {
+                    window.PebbleBridgeNative.storageRemove(key, makeCallback(resolve, reject));
+                });
+            }
+        },
+        close: function(returnValue) {
+            window.PebbleBridgeNative.close(JSON.stringify(returnValue || {}));
+        }
+    };
+})();

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeFetch.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeFetch.kt
@@ -1,8 +1,6 @@
 package coredevices.pebble.config.bridge
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.headers
 import io.ktor.client.request.request
@@ -18,17 +16,7 @@ import io.ktor.util.flattenEntries
  * Performs HTTP requests through Ktor/OkHttp so the config page is not subject to
  * WebView CORS or mixed-content restrictions.
  */
-class BridgeFetch {
-
-    private val client = HttpClient(OkHttp) {
-        install(HttpTimeout)
-        engine {
-            config {
-                followRedirects(true)
-                retryOnConnectionFailure(true)
-            }
-        }
-    }
+class BridgeFetch(private val client: HttpClient) {
 
     suspend fun execute(request: FetchRequest): FetchResponse {
         val response: HttpResponse = client.request(request.url) {

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeFetch.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeFetch.kt
@@ -1,0 +1,73 @@
+package coredevices.pebble.config.bridge
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.headers
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.Headers
+import io.ktor.http.HttpMethod
+import io.ktor.http.isSuccess
+import io.ktor.util.flattenEntries
+
+/**
+ * Performs HTTP requests through Ktor/OkHttp so the config page is not subject to
+ * WebView CORS or mixed-content restrictions.
+ */
+class BridgeFetch {
+
+    private val client = HttpClient(OkHttp) {
+        install(HttpTimeout)
+        engine {
+            config {
+                followRedirects(true)
+                retryOnConnectionFailure(true)
+            }
+        }
+    }
+
+    suspend fun execute(request: FetchRequest): FetchResponse {
+        val response: HttpResponse = client.request(request.url) {
+            method = parseMethod(request.method)
+            timeout {
+                requestTimeoutMillis = request.timeout
+                connectTimeoutMillis = 30_000
+            }
+            headers {
+                request.headers.forEach { (key, value) ->
+                    append(key, value)
+                }
+            }
+            request.body?.let { setBody(it) }
+        }
+
+        val body = response.bodyAsText()
+        return FetchResponse(
+            ok = response.status.isSuccess(),
+            status = response.status.value,
+            statusText = response.status.description,
+            headers = response.headers.toMap(),
+            body = body,
+        )
+    }
+
+    private fun parseMethod(method: String): HttpMethod = when (method.uppercase()) {
+        "GET" -> HttpMethod.Get
+        "POST" -> HttpMethod.Post
+        "PUT" -> HttpMethod.Put
+        "DELETE" -> HttpMethod.Delete
+        "PATCH" -> HttpMethod.Patch
+        "HEAD" -> HttpMethod.Head
+        "OPTIONS" -> HttpMethod.Options
+        else -> HttpMethod.parse(method)
+    }
+
+    private fun Headers.toMap(): Map<String, String> {
+        return flattenEntries().groupBy({ it.first }, { it.second })
+            .mapValues { it.value.joinToString(", ") }
+    }
+}

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeStorage.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeStorage.kt
@@ -1,0 +1,39 @@
+package coredevices.pebble.config.bridge
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Encrypted key/value store scoped to a single watch app UUID.
+ *
+ * Values are encrypted at rest using EncryptedSharedPreferences and are not shared
+ * between different watch apps.
+ */
+class BridgeStorage(context: Context, appUuid: String) {
+
+    private val prefs: SharedPreferences by lazy {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        EncryptedSharedPreferences.create(
+            context,
+            "pebble_bridge_${appUuid}",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    fun get(key: String): String? = prefs.getString(key, null)
+
+    fun set(key: String, value: String) {
+        prefs.edit().putString(key, value).apply()
+    }
+
+    fun remove(key: String) {
+        prefs.edit().remove(key).apply()
+    }
+}

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeWebSocket.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeWebSocket.kt
@@ -71,6 +71,5 @@ class BridgeWebSocket(private val client: HttpClient) {
 
     fun dispose() {
         scope.cancel()
-        client.close()
     }
 }

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeWebSocket.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeWebSocket.kt
@@ -1,8 +1,7 @@
 package coredevices.pebble.config.bridge
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.request.header
 import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.websocket.Frame
 import io.ktor.websocket.CloseReason
@@ -22,7 +21,7 @@ import kotlinx.coroutines.launch
  * Messages are forwarded in both directions. The native app owns TLS validation,
  * so self-signed/user-CA certificates trusted at the OS level work automatically.
  */
-class BridgeWebSocket {
+class BridgeWebSocket(private val client: HttpClient) {
 
     interface JsListener {
         fun onOpen()
@@ -31,22 +30,13 @@ class BridgeWebSocket {
         fun onFailure(t: Throwable)
     }
 
-    private val client = HttpClient(OkHttp) {
-        install(WebSockets)
-        engine {
-            config {
-                followRedirects(true)
-                retryOnConnectionFailure(true)
-            }
-        }
-    }
-
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     suspend fun connect(url: String, protocols: List<String>, listener: JsListener): WebSocketSession {
         val session = client.webSocketSession(url) {
-            // Ktor OkHttp engine will send the subprotocol if requested.
-            // Note: protocols handling depends on engine support.
+            if (protocols.isNotEmpty()) {
+                header(io.ktor.http.HttpHeaders.SecWebSocketProtocol, protocols.joinToString(", "))
+            }
         }
 
         scope.launch {

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeWebSocket.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/BridgeWebSocket.kt
@@ -1,0 +1,86 @@
+package coredevices.pebble.config.bridge
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.websocket.Frame
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.WebSocketSession
+import io.ktor.websocket.close
+import io.ktor.websocket.readReason
+import io.ktor.websocket.readText
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+/**
+ * Bridges a JavaScript WebSocket to a Ktor/OkHttp WebSocket session.
+ *
+ * Messages are forwarded in both directions. The native app owns TLS validation,
+ * so self-signed/user-CA certificates trusted at the OS level work automatically.
+ */
+class BridgeWebSocket {
+
+    interface JsListener {
+        fun onOpen()
+        fun onMessage(text: String)
+        fun onClosing(code: Short, reason: String)
+        fun onFailure(t: Throwable)
+    }
+
+    private val client = HttpClient(OkHttp) {
+        install(WebSockets)
+        engine {
+            config {
+                followRedirects(true)
+                retryOnConnectionFailure(true)
+            }
+        }
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    suspend fun connect(url: String, protocols: List<String>, listener: JsListener): WebSocketSession {
+        val session = client.webSocketSession(url) {
+            // Ktor OkHttp engine will send the subprotocol if requested.
+            // Note: protocols handling depends on engine support.
+        }
+
+        scope.launch {
+            try {
+                listener.onOpen()
+                for (frame in session.incoming) {
+                    when (frame) {
+                        is Frame.Text -> listener.onMessage(frame.readText())
+                        is Frame.Close -> {
+                            val reason = frame.readReason()
+                            listener.onClosing(reason?.code ?: 1000.toShort(), reason?.message ?: "")
+                            break
+                        }
+                        else -> { /* ignore binary/continuation frames */ }
+                    }
+                }
+            } catch (t: Throwable) {
+                listener.onFailure(t)
+            }
+        }
+
+        return session
+    }
+
+    suspend fun send(session: WebSocketSession, data: String) {
+        session.send(Frame.Text(data))
+    }
+
+    suspend fun close(session: WebSocketSession, code: Short, reason: String) {
+        session.close(CloseReason(code, reason))
+    }
+
+    fun dispose() {
+        scope.cancel()
+        client.close()
+    }
+}

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt
@@ -1,7 +1,13 @@
 package coredevices.pebble.config.bridge
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.webkit.WebView
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.websocket.WebSockets
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,7 +24,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * val bridge = PebbleBridgeManager(
  *     context = webView.context,
  *     appUuid = uuid.toString(),
- *     config = mapOf("ha_url" to "...", "token" to "..."),
+ *     config = mapOf("ha_url" to "...", "token" to ""),
  *     onClose = { returnValueJson ->
  *         // forward to PKJS session triggerOnWebviewClosed(returnValueJson)
  *     }
@@ -27,7 +33,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * ```
  */
 class PebbleBridgeManager(
-    context: Context,
+    private val context: Context,
     appUuid: String,
     config: Map<String, String>,
     private val onClose: (String) -> Unit,
@@ -35,15 +41,31 @@ class PebbleBridgeManager(
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val storage = BridgeStorage(context, appUuid)
-    private val fetcher = BridgeFetch()
-    private val webSocketFactory = BridgeWebSocket()
+
+    /**
+     * Single Ktor/OkHttp client shared by fetch and WebSocket. Both plugins are
+     * installed once so redirects, timeouts, and TLS are configured in one place.
+     */
+    private val httpClient = HttpClient(OkHttp) {
+        install(HttpTimeout)
+        install(WebSockets)
+        engine {
+            config {
+                followRedirects(true)
+                retryOnConnectionFailure(true)
+            }
+        }
+    }
+
+    private val fetcher = BridgeFetch(httpClient)
+    private val webSocketFactory = BridgeWebSocket(httpClient)
 
     private val configJson = buildConfigJson(config)
 
     private val evaluateJavascript: (String) -> Unit = { script ->
         // Posts to the main thread; the caller must call this only when the WebView
         // is attached to a window. The attach() helper below handles that safely.
-        android.os.Handler(android.os.Looper.getMainLooper()).post {
+        Handler(Looper.getMainLooper()).post {
             currentWebView?.evaluateJavascript(script, null)
         }
     }
@@ -63,142 +85,14 @@ class PebbleBridgeManager(
         fun parseConfigFromUrlHash(url: String): Map<String, String> =
             parseBridgeConfigFromUrlHash(url)
 
-        /**
-         * JavaScript shim that turns the native string bridge into the Promise-based
-         * `window.pebbleBridge` API expected by config pages.
-         */
-        val bridgeJsShim: String = """
-(function() {
-    if (window.pebbleBridge) return;
-
-    function makeCallback(resolve, reject) {
-        const id = 'cb_' + Math.random().toString(36).slice(2);
-        window.__pebbleBridgeCallbacks = window.__pebbleBridgeCallbacks || {};
-        window.__pebbleBridgeCallbacks[id] = {
-            resolve: function(v) {
-                delete window.__pebbleBridgeCallbacks[id];
-                resolve(v);
-            },
-            reject: function(e) {
-                delete window.__pebbleBridgeCallbacks[id];
-                reject(new Error(e));
-            }
-        };
-        return id;
-    }
-
-    function BridgeResponse(raw) {
-        const data = (typeof raw === 'string') ? JSON.parse(raw) : raw;
-        this.ok = data.ok;
-        this.status = data.status;
-        this.statusText = data.statusText;
-        this.headers = data.headers || {};
-        this._body = data.body || '';
-    }
-    BridgeResponse.prototype.text = function() {
-        return Promise.resolve(typeof this._body === 'string' ? this._body : JSON.stringify(this._body));
-    };
-    BridgeResponse.prototype.json = function() {
-        if (typeof this._body === 'string') {
-            return Promise.resolve(JSON.parse(this._body));
-        }
-        return Promise.resolve(this._body);
-    };
-
-    function BridgeWebSocket(url, protocols) {
-        const self = this;
-        protocols = protocols || [];
-        this.url = url;
-        this.readyState = 0;
-        this.id = 'ws_' + Math.random().toString(36).slice(2);
-        window.__pebbleBridgeWebSockets = window.__pebbleBridgeWebSockets || {};
-        window.__pebbleBridgeWebSockets[this.id] = this;
-        this.onopen = null;
-        this.onmessage = null;
-        this.onerror = null;
-        this.onclose = null;
-
-        // Native bridge emits events by calling these methods on the socket object.
-        this.open = function() {
-            self.readyState = BridgeWebSocket.OPEN;
-            if (self.onopen) self.onopen();
-        };
-        this.message = function(data) {
-            if (self.onmessage) self.onmessage({ data: data });
-        };
-        this.error = function(msg) {
-            if (self.onerror) self.onerror(new Error(msg));
-        };
-        // Native emits close event with {code, reason}; user calls close(code, reason).
-        this.close = function(arg1, arg2) {
-            if (arg1 && typeof arg1 === 'object' && 'code' in arg1) {
-                self.readyState = BridgeWebSocket.CLOSED;
-                if (self.onclose) self.onclose({ code: arg1.code, reason: arg1.reason || '', wasClean: arg1.code === 1000 });
-            } else {
-                self.readyState = BridgeWebSocket.CLOSING;
-                window.PebbleBridgeNative.webSocketClose(self.id, arg1 || 1000, arg2 || '');
-            }
-        };
-
-        window.PebbleBridgeNative.webSocketConnect(this.id, url, JSON.stringify(protocols));
-
-        this.send = function(data) {
-            window.PebbleBridgeNative.webSocketSend(self.id, data);
-        };
-    }
-    BridgeWebSocket.CONNECTING = 0;
-    BridgeWebSocket.OPEN = 1;
-    BridgeWebSocket.CLOSING = 2;
-    BridgeWebSocket.CLOSED = 3;
-
-    window.pebbleBridge = {
-        version: window.PebbleBridgeNative.version(),
-        config: JSON.parse(window.PebbleBridgeNative.getConfig()),
-        fetch: function(url, options) {
-            options = options || {};
-            return new Promise(function(resolve, reject) {
-                const req = {
-                    url: url,
-                    method: options.method || 'GET',
-                    headers: options.headers || {},
-                    body: options.body || null,
-                    timeout: options.timeout || 30000
-                };
-                window.PebbleBridgeNative.fetch(
-                    JSON.stringify(req),
-                    makeCallback(function(raw) { resolve(new BridgeResponse(raw)); }, reject)
-                );
-            });
-        },
-        WebSocket: BridgeWebSocket,
-        storage: {
-            get: function(key) {
-                return new Promise(function(resolve, reject) {
-                    window.PebbleBridgeNative.storageGet(key, makeCallback(resolve, reject));
-                });
-            },
-            set: function(key, value) {
-                return new Promise(function(resolve, reject) {
-                    window.PebbleBridgeNative.storageSet(key, value, makeCallback(resolve, reject));
-                });
-            },
-            remove: function(key) {
-                return new Promise(function(resolve, reject) {
-                    window.PebbleBridgeNative.storageRemove(key, makeCallback(resolve, reject));
-                });
-            }
-        },
-        close: function(returnValue) {
-            window.PebbleBridgeNative.close(JSON.stringify(returnValue || {}));
-        }
-    };
-})();
-        """.trimIndent()
-
         private fun buildConfigJson(config: Map<String, String>): String {
             val json = JsonObject(config.mapValues { JsonPrimitive(it.value) })
             return bridgeJson.encodeToString(JsonObject.serializer(), json)
         }
+    }
+
+    private val bridgeJsShim: String by lazy {
+        context.assets.open("bridge-shim.js").bufferedReader().use { it.readText() }
     }
 
     val nativeInterface = PebbleBridgeNativeInterface(
@@ -231,7 +125,8 @@ class PebbleBridgeManager(
     }
 
     fun dispose() {
-        nativeInterface.close("{}")
+        nativeInterface.dispose()
+        httpClient.close()
         scope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
     }
 }

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt
@@ -1,0 +1,211 @@
+package coredevices.pebble.config.bridge
+
+import android.content.Context
+import android.webkit.WebView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Convenience builder that wires together the encrypted store, fetch, WebSocket,
+ * and JavaScript interface for a single config page session.
+ *
+ * Typical usage inside [webViewFactory]:
+ *
+ * ```kotlin
+ * val bridge = PebbleBridgeManager(
+ *     context = webView.context,
+ *     appUuid = uuid.toString(),
+ *     config = mapOf("ha_url" to "...", "token" to "..."),
+ *     onClose = { returnValueJson ->
+ *         // forward to PKJS session triggerOnWebviewClosed(returnValueJson)
+ *     }
+ * )
+ * bridge.attach(webView)
+ * ```
+ */
+class PebbleBridgeManager(
+    context: Context,
+    appUuid: String,
+    config: Map<String, String>,
+    private val onClose: (String) -> Unit,
+) {
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val storage = BridgeStorage(context, appUuid)
+    private val fetcher = BridgeFetch()
+    private val webSocketFactory = BridgeWebSocket()
+
+    private val configJson = buildConfigJson(config)
+
+    private val evaluateJavascript: (String) -> Unit = { script ->
+        // Posts to the main thread; the caller must call this only when the WebView
+        // is attached to a window. The attach() helper below handles that safely.
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            currentWebView?.evaluateJavascript(script, null)
+        }
+    }
+
+    private var currentWebView: WebView? = null
+
+    companion object {
+
+        /**
+         * Parses the URL hash and returns the decoded settings as a plain string map.
+         *
+         * Config pages currently encode settings in the URL hash (e.g.
+         * `https://.../config.html#%7B%22token%22%3A%22...%22%7D`). The bridge exposes
+         * these through `window.pebbleBridge.config` so the page no longer has to read
+         * the URL itself.
+         */
+        fun parseConfigFromUrlHash(url: String): Map<String, String> =
+            parseBridgeConfigFromUrlHash(url)
+
+        /**
+         * JavaScript shim that turns the native string bridge into the Promise-based
+         * `window.pebbleBridge` API expected by config pages.
+         */
+        val bridgeJsShim: String = """
+(function() {
+    if (window.pebbleBridge) return;
+
+    function makeCallback(resolve, reject) {
+        const id = 'cb_' + Math.random().toString(36).slice(2);
+        window.__pebbleBridgeCallbacks = window.__pebbleBridgeCallbacks || {};
+        window.__pebbleBridgeCallbacks[id] = {
+            resolve: function(v) {
+                delete window.__pebbleBridgeCallbacks[id];
+                resolve(v);
+            },
+            reject: function(e) {
+                delete window.__pebbleBridgeCallbacks[id];
+                reject(new Error(e));
+            }
+        };
+        return id;
+    }
+
+    function BridgeResponse(raw) {
+        const data = JSON.parse(raw);
+        this.ok = data.ok;
+        this.status = data.status;
+        this.statusText = data.statusText;
+        this.headers = data.headers || {};
+        this._body = data.body || '';
+    }
+    BridgeResponse.prototype.text = function() { return Promise.resolve(this._body); };
+    BridgeResponse.prototype.json = function() { return Promise.resolve(JSON.parse(this._body)); };
+
+    function BridgeWebSocket(url, protocols) {
+        const self = this;
+        protocols = protocols || [];
+        this.url = url;
+        this.readyState = 0;
+        this.id = 'ws_' + Math.random().toString(36).slice(2);
+        window.__pebbleBridgeWebSockets = window.__pebbleBridgeWebSockets || {};
+        window.__pebbleBridgeWebSockets[this.id] = this;
+        this.onopen = null;
+        this.onmessage = null;
+        this.onerror = null;
+        this.onclose = null;
+
+        window.PebbleBridgeNative.webSocketConnect(this.id, url, JSON.stringify(protocols));
+
+        this.send = function(data) {
+            window.PebbleBridgeNative.webSocketSend(self.id, data);
+        };
+        this.close = function(code, reason) {
+            window.PebbleBridgeNative.webSocketClose(self.id, code || 1000, reason || '');
+        };
+    }
+    BridgeWebSocket.CONNECTING = 0;
+    BridgeWebSocket.OPEN = 1;
+    BridgeWebSocket.CLOSING = 2;
+    BridgeWebSocket.CLOSED = 3;
+
+    window.pebbleBridge = {
+        version: window.PebbleBridgeNative.version(),
+        config: JSON.parse(window.PebbleBridgeNative.getConfig()),
+        fetch: function(url, options) {
+            options = options || {};
+            return new Promise(function(resolve, reject) {
+                const req = {
+                    url: url,
+                    method: options.method || 'GET',
+                    headers: options.headers || {},
+                    body: options.body || null,
+                    timeout: options.timeout || 30000
+                };
+                window.PebbleBridgeNative.fetch(
+                    JSON.stringify(req),
+                    makeCallback(function(raw) { resolve(new BridgeResponse(raw)); }, reject)
+                );
+            });
+        },
+        WebSocket: BridgeWebSocket,
+        storage: {
+            get: function(key) {
+                return new Promise(function(resolve, reject) {
+                    window.PebbleBridgeNative.storageGet(key, makeCallback(resolve, reject));
+                });
+            },
+            set: function(key, value) {
+                return new Promise(function(resolve, reject) {
+                    window.PebbleBridgeNative.storageSet(key, value, makeCallback(resolve, reject));
+                });
+            },
+            remove: function(key) {
+                return new Promise(function(resolve, reject) {
+                    window.PebbleBridgeNative.storageRemove(key, makeCallback(resolve, reject));
+                });
+            }
+        },
+        close: function(returnValue) {
+            window.PebbleBridgeNative.close(JSON.stringify(returnValue || {}));
+        }
+    };
+})();
+        """.trimIndent()
+
+        private fun buildConfigJson(config: Map<String, String>): String {
+            val json = JsonObject(config.mapValues { JsonPrimitive(it.value) })
+            return bridgeJson.encodeToString(JsonObject.serializer(), json)
+        }
+    }
+
+    val nativeInterface = PebbleBridgeNativeInterface(
+        scope = scope,
+        configJson = configJson,
+        storage = storage,
+        fetcher = fetcher,
+        webSocketFactory = webSocketFactory,
+        onClose = onClose,
+        evaluateJavascript = evaluateJavascript,
+    )
+
+    /**
+     * Registers the native interface and the JS shim on the given WebView.
+     * Safe to call from a factory that creates NativeWebView wrappers.
+     */
+    fun attach(webView: WebView) {
+        currentWebView = webView
+        webView.addJavascriptInterface(nativeInterface, "PebbleBridgeNative")
+        webView.evaluateJavascript(bridgeJsShim, null)
+    }
+
+    /**
+     * Re-injects the JS shim. Call from a page-finished listener when the page
+     * navigates to a new document.
+     */
+    fun reInject(webView: WebView) {
+        currentWebView = webView
+        webView.evaluateJavascript(bridgeJsShim, null)
+    }
+
+    fun dispose() {
+        nativeInterface.close("{}")
+        scope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+    }
+}

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt
@@ -88,15 +88,22 @@ class PebbleBridgeManager(
     }
 
     function BridgeResponse(raw) {
-        const data = JSON.parse(raw);
+        const data = (typeof raw === 'string') ? JSON.parse(raw) : raw;
         this.ok = data.ok;
         this.status = data.status;
         this.statusText = data.statusText;
         this.headers = data.headers || {};
         this._body = data.body || '';
     }
-    BridgeResponse.prototype.text = function() { return Promise.resolve(this._body); };
-    BridgeResponse.prototype.json = function() { return Promise.resolve(JSON.parse(this._body)); };
+    BridgeResponse.prototype.text = function() {
+        return Promise.resolve(typeof this._body === 'string' ? this._body : JSON.stringify(this._body));
+    };
+    BridgeResponse.prototype.json = function() {
+        if (typeof this._body === 'string') {
+            return Promise.resolve(JSON.parse(this._body));
+        }
+        return Promise.resolve(this._body);
+    };
 
     function BridgeWebSocket(url, protocols) {
         const self = this;
@@ -111,13 +118,32 @@ class PebbleBridgeManager(
         this.onerror = null;
         this.onclose = null;
 
+        // Native bridge emits events by calling these methods on the socket object.
+        this.open = function() {
+            self.readyState = BridgeWebSocket.OPEN;
+            if (self.onopen) self.onopen();
+        };
+        this.message = function(data) {
+            if (self.onmessage) self.onmessage({ data: data });
+        };
+        this.error = function(msg) {
+            if (self.onerror) self.onerror(new Error(msg));
+        };
+        // Native emits close event with {code, reason}; user calls close(code, reason).
+        this.close = function(arg1, arg2) {
+            if (arg1 && typeof arg1 === 'object' && 'code' in arg1) {
+                self.readyState = BridgeWebSocket.CLOSED;
+                if (self.onclose) self.onclose({ code: arg1.code, reason: arg1.reason || '', wasClean: arg1.code === 1000 });
+            } else {
+                self.readyState = BridgeWebSocket.CLOSING;
+                window.PebbleBridgeNative.webSocketClose(self.id, arg1 || 1000, arg2 || '');
+            }
+        };
+
         window.PebbleBridgeNative.webSocketConnect(this.id, url, JSON.stringify(protocols));
 
         this.send = function(data) {
             window.PebbleBridgeNative.webSocketSend(self.id, data);
-        };
-        this.close = function(code, reason) {
-            window.PebbleBridgeNative.webSocketClose(self.id, code || 1000, reason || '');
         };
     }
     BridgeWebSocket.CONNECTING = 0;

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeNativeInterface.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeNativeInterface.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
-import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -56,7 +56,7 @@ class PebbleBridgeNativeInterface(
                 throw e
             } catch (t: Throwable) {
                 logger.e(t) { "fetch failed: ${t.message}" }
-                emit(callbackId, "reject", JSONObject.quote(t.message ?: "network error"))
+                emit(callbackId, "reject", quoteJsString(t.message ?: "network error"))
             }
         }
     }
@@ -64,7 +64,7 @@ class PebbleBridgeNativeInterface(
     @JavascriptInterface
     fun storageGet(key: String, callbackId: String) {
         val value = storage.get(key)
-        emit(callbackId, "resolve", if (value == null) "null" else JSONObject.quote(value))
+        emit(callbackId, "resolve", if (value == null) "null" else quoteJsString(value))
     }
 
     @JavascriptInterface
@@ -86,7 +86,7 @@ class PebbleBridgeNativeInterface(
             bridgeJson.decodeFromString(ListSerializer(String.serializer()), protocolsJson)
         } catch (t: Throwable) {
             logger.e(t) { "Failed to parse protocols" }
-            emitSocket(socketId, "error", JSONObject.quote("invalid protocols"))
+            emitSocket(socketId, "error", quoteJsString("invalid protocols"))
             return
         }
 
@@ -98,23 +98,24 @@ class PebbleBridgeNativeInterface(
                     }
 
                     override fun onMessage(text: String) {
-                        emitSocket(socketId, "message", JSONObject.quote(text))
+                        emitSocket(socketId, "message", quoteJsString(text))
                     }
 
                     override fun onClosing(code: Short, reason: String) {
-                        emitSocket(socketId, "close", """{"code":$code,"reason":"${escapeJson(reason)}"}""")
+                        val payload = bridgeJson.encodeToString(WebSocketCloseEvent.serializer(), WebSocketCloseEvent(code, reason))
+                        emitSocket(socketId, "close", payload)
                         webSockets.remove(socketId)
                     }
 
                     override fun onFailure(t: Throwable) {
                         logger.e(t) { "websocket error: ${t.message}" }
-                        emitSocket(socketId, "error", JSONObject.quote(t.message ?: "websocket error"))
+                        emitSocket(socketId, "error", quoteJsString(t.message ?: "websocket error"))
                     }
                 })
                 webSockets[socketId] = session
             } catch (t: Throwable) {
                 logger.e(t) { "websocket connect failed: ${t.message}" }
-                emitSocket(socketId, "error", JSONObject.quote(t.message ?: "websocket connect failed"))
+                emitSocket(socketId, "error", quoteJsString(t.message ?: "websocket connect failed"))
             }
         }
     }
@@ -145,6 +146,19 @@ class PebbleBridgeNativeInterface(
 
     @JavascriptInterface
     fun close(returnValueJson: String) {
+        closeResources()
+        onClose(returnValueJson)
+    }
+
+    /**
+     * Tears down sockets and marks the bridge inactive without invoking the close callback.
+     * Used when the containing screen is disposed without an explicit JS close() call.
+     */
+    fun dispose() {
+        closeResources()
+    }
+
+    private fun closeResources() {
         active = false
         scope.launch(Dispatchers.IO) {
             webSockets.values.forEach { session ->
@@ -155,7 +169,6 @@ class PebbleBridgeNativeInterface(
             webSockets.clear()
             webSocketFactory.dispose()
         }
-        onClose(returnValueJson)
     }
 
     private fun emit(callbackId: String, method: String, payload: String) {
@@ -168,15 +181,11 @@ class PebbleBridgeNativeInterface(
         evaluateJavascript(js)
     }
 
-    private fun escapeJson(text: String): String {
-        return text
-            .replace("\\", "\\\\")
-            .replace("\"", "\\\"")
-            .replace("\b", "\\b")
-            .replace("\n", "\\n")
-            .replace("\r", "\\r")
-            .replace("\t", "\\t")
-    }
+    private fun quoteJsString(text: String): String =
+        bridgeJson.encodeToString(String.serializer(), text)
+
+    @Serializable
+    private data class WebSocketCloseEvent(val code: Short, val reason: String)
 
     companion object {
         const val VERSION = "1.0.0"

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeNativeInterface.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeNativeInterface.kt
@@ -1,0 +1,184 @@
+package coredevices.pebble.config.bridge
+
+import android.webkit.JavascriptInterface
+import co.touchlab.kermit.Logger
+import io.ktor.websocket.WebSocketSession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The native side of `window.pebbleBridge`.
+ *
+ * This class is registered on the WebView via [addJavascriptInterface]. A small JS shim
+ * (injected on page load) adapts the string-based native methods to the Promise-based
+ * JavaScript API defined in `bridge-spec.md`.
+ */
+class PebbleBridgeNativeInterface(
+    private val scope: CoroutineScope,
+    private val configJson: String,
+    private val storage: BridgeStorage,
+    private val fetcher: BridgeFetch,
+    private val webSocketFactory: BridgeWebSocket,
+    private val onClose: (String) -> Unit,
+    private val evaluateJavascript: (String) -> Unit,
+) {
+
+    private val logger = Logger.withTag("PebbleBridge")
+
+    @Volatile
+    var active = true
+        private set
+
+    private val webSockets = ConcurrentHashMap<String, WebSocketSession>()
+
+    @JavascriptInterface
+    fun version(): String = VERSION
+
+    @JavascriptInterface
+    fun getConfig(): String = configJson
+
+    @JavascriptInterface
+    fun fetch(requestJson: String, callbackId: String) {
+        if (!active) return
+        scope.launch(Dispatchers.IO) {
+            try {
+                val request = bridgeJson.decodeFromString(FetchRequest.serializer(), requestJson)
+                val response = fetcher.execute(request)
+                val responseJson = bridgeJson.encodeToString(FetchResponse.serializer(), response)
+                emit(callbackId, "resolve", responseJson)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (t: Throwable) {
+                logger.e(t) { "fetch failed: ${t.message}" }
+                emit(callbackId, "reject", JSONObject.quote(t.message ?: "network error"))
+            }
+        }
+    }
+
+    @JavascriptInterface
+    fun storageGet(key: String, callbackId: String) {
+        val value = storage.get(key)
+        emit(callbackId, "resolve", if (value == null) "null" else JSONObject.quote(value))
+    }
+
+    @JavascriptInterface
+    fun storageSet(key: String, value: String, callbackId: String) {
+        storage.set(key, value)
+        emit(callbackId, "resolve", "true")
+    }
+
+    @JavascriptInterface
+    fun storageRemove(key: String, callbackId: String) {
+        storage.remove(key)
+        emit(callbackId, "resolve", "true")
+    }
+
+    @JavascriptInterface
+    fun webSocketConnect(socketId: String, url: String, protocolsJson: String) {
+        if (!active) return
+        val protocols = try {
+            bridgeJson.decodeFromString(ListSerializer(String.serializer()), protocolsJson)
+        } catch (t: Throwable) {
+            logger.e(t) { "Failed to parse protocols" }
+            emitSocket(socketId, "error", JSONObject.quote("invalid protocols"))
+            return
+        }
+
+        scope.launch(Dispatchers.IO) {
+            try {
+                val session = webSocketFactory.connect(url, protocols, object : BridgeWebSocket.JsListener {
+                    override fun onOpen() {
+                        emitSocket(socketId, "open", "")
+                    }
+
+                    override fun onMessage(text: String) {
+                        emitSocket(socketId, "message", JSONObject.quote(text))
+                    }
+
+                    override fun onClosing(code: Short, reason: String) {
+                        emitSocket(socketId, "close", """{"code":$code,"reason":"${escapeJson(reason)}"}""")
+                        webSockets.remove(socketId)
+                    }
+
+                    override fun onFailure(t: Throwable) {
+                        logger.e(t) { "websocket error: ${t.message}" }
+                        emitSocket(socketId, "error", JSONObject.quote(t.message ?: "websocket error"))
+                    }
+                })
+                webSockets[socketId] = session
+            } catch (t: Throwable) {
+                logger.e(t) { "websocket connect failed: ${t.message}" }
+                emitSocket(socketId, "error", JSONObject.quote(t.message ?: "websocket connect failed"))
+            }
+        }
+    }
+
+    @JavascriptInterface
+    fun webSocketSend(socketId: String, data: String) {
+        val session = webSockets[socketId] ?: return
+        scope.launch(Dispatchers.IO) {
+            try {
+                webSocketFactory.send(session, data)
+            } catch (t: Throwable) {
+                logger.e(t) { "websocket send failed: ${t.message}" }
+            }
+        }
+    }
+
+    @JavascriptInterface
+    fun webSocketClose(socketId: String, code: Int, reason: String) {
+        val session = webSockets.remove(socketId) ?: return
+        scope.launch(Dispatchers.IO) {
+            try {
+                webSocketFactory.close(session, code.toShort(), reason)
+            } catch (t: Throwable) {
+                logger.e(t) { "websocket close failed: ${t.message}" }
+            }
+        }
+    }
+
+    @JavascriptInterface
+    fun close(returnValueJson: String) {
+        active = false
+        scope.launch(Dispatchers.IO) {
+            webSockets.values.forEach { session ->
+                try {
+                    webSocketFactory.close(session, 1000, "config closed")
+                } catch (_: Throwable) { }
+            }
+            webSockets.clear()
+            webSocketFactory.dispose()
+        }
+        onClose(returnValueJson)
+    }
+
+    private fun emit(callbackId: String, method: String, payload: String) {
+        val js = "window.__pebbleBridgeCallbacks['$callbackId'] && window.__pebbleBridgeCallbacks['$callbackId'].$method($payload);"
+        evaluateJavascript(js)
+    }
+
+    private fun emitSocket(socketId: String, event: String, payload: String) {
+        val js = "window.__pebbleBridgeWebSockets['$socketId'] && window.__pebbleBridgeWebSockets['$socketId'].$event($payload);"
+        evaluateJavascript(js)
+    }
+
+    private fun escapeJson(text: String): String {
+        return text
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\b", "\\b")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+    }
+
+    companion object {
+        const val VERSION = "1.0.0"
+    }
+}

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.android.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.android.kt
@@ -3,6 +3,7 @@ package coredevices.pebble.ui
 import com.multiplatform.webview.web.NativeWebView
 import com.multiplatform.webview.web.WebViewFactoryParam
 import com.multiplatform.webview.web.defaultWebViewFactory
+import coredevices.pebble.config.bridge.PebbleBridgeManager
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.io.rebble.libpebblecommon.js.WebViewJSLocalStorageInterface
 import kotlinx.coroutines.Dispatchers
@@ -13,7 +14,10 @@ import kotlin.uuid.Uuid
 
 internal actual fun webViewFactory(
     params: WebViewFactoryParam,
-    uuid: Uuid
+    uuid: Uuid,
+    bridgeEnabled: Boolean,
+    bridgeConfig: Map<String, String>,
+    onBridgeClose: (String) -> Unit,
 ): NativeWebView = defaultWebViewFactory(params).apply {
     // Don't store the webview state (which includes localstorage) in bundle - can be too large
     isSaveEnabled = false
@@ -28,6 +32,16 @@ internal actual fun webViewFactory(
     addJavascriptInterface(localStorageInterface, "_localStorage")
     settings.domStorageEnabled = true
     settings.databasePath = Path(context.filesDir.path, "watchapp_settings/$uuid").toString()
+
+    if (bridgeEnabled) {
+        val bridge = PebbleBridgeManager(
+            context = context,
+            appUuid = uuid.toString(),
+            config = bridgeConfig,
+            onClose = onBridgeClose,
+        )
+        bridge.attach(this)
+    }
 }
 
 internal actual suspend fun restoreLocalStorage(webView: NativeWebView) {

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.android.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.android.kt
@@ -1,5 +1,7 @@
 package coredevices.pebble.ui
 
+import android.os.Handler
+import android.os.Looper
 import co.touchlab.kermit.Logger
 import com.multiplatform.webview.web.NativeWebView
 import com.multiplatform.webview.web.WebViewFactoryParam
@@ -8,7 +10,6 @@ import coredevices.pebble.config.bridge.PebbleBridgeManager
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.io.rebble.libpebblecommon.js.WebViewJSLocalStorageInterface
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.io.path.Path
 import kotlin.uuid.Uuid
@@ -25,12 +26,9 @@ internal actual fun webViewFactory(
     logger.d { "webViewFactory called uuid=$uuid bridgeEnabled=$bridgeEnabled configKeys=${bridgeConfig.keys}" }
     // Don't store the webview state (which includes localstorage) in bundle - can be too large
     isSaveEnabled = false
-    val localStorageInterface = WebViewJSLocalStorageInterface("$uuid-config", AppContext(context)) {
-        runBlocking(Dispatchers.Main) {
-            evaluateJavascript(
-                it,
-                null
-            )
+    val localStorageInterface = WebViewJSLocalStorageInterface("$uuid-config", AppContext(context)) { script ->
+        Handler(Looper.getMainLooper()).post {
+            evaluateJavascript(script, null)
         }
     }
     addJavascriptInterface(localStorageInterface, "_localStorage")
@@ -64,7 +62,7 @@ internal actual suspend fun restoreLocalStorage(webView: NativeWebView) {
 }
 
 internal actual fun persistLocalStorage(webView: NativeWebView) {
-    runBlocking(Dispatchers.Main) {
+    Handler(Looper.getMainLooper()).post {
         webView.evaluateJavascript("""
             (function() {
                 const data = {};

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.android.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.android.kt
@@ -1,5 +1,6 @@
 package coredevices.pebble.ui
 
+import co.touchlab.kermit.Logger
 import com.multiplatform.webview.web.NativeWebView
 import com.multiplatform.webview.web.WebViewFactoryParam
 import com.multiplatform.webview.web.defaultWebViewFactory
@@ -12,6 +13,8 @@ import kotlinx.coroutines.withContext
 import kotlin.io.path.Path
 import kotlin.uuid.Uuid
 
+private val logger = Logger.withTag("WatchappSettingsBridge")
+
 internal actual fun webViewFactory(
     params: WebViewFactoryParam,
     uuid: Uuid,
@@ -19,6 +22,7 @@ internal actual fun webViewFactory(
     bridgeConfig: Map<String, String>,
     onBridgeClose: (String) -> Unit,
 ): NativeWebView = defaultWebViewFactory(params).apply {
+    logger.d { "webViewFactory called uuid=$uuid bridgeEnabled=$bridgeEnabled configKeys=${bridgeConfig.keys}" }
     // Don't store the webview state (which includes localstorage) in bundle - can be too large
     isSaveEnabled = false
     val localStorageInterface = WebViewJSLocalStorageInterface("$uuid-config", AppContext(context)) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/config/bridge/BridgeConfigParser.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/config/bridge/BridgeConfigParser.kt
@@ -1,0 +1,35 @@
+package coredevices.pebble.config.bridge
+
+import io.ktor.http.decodeURLPart
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Parses the URL hash and returns the decoded settings as a plain string map.
+ *
+ * Config pages currently encode settings in the URL hash (e.g.
+ * `https://.../config.html#%7B%22token%22%3A%22...%22%7D`). The bridge exposes
+ * these through `window.pebbleBridge.config` so the page no longer has to read
+ * the URL itself.
+ */
+fun parseBridgeConfigFromUrlHash(url: String): Map<String, String> {
+    val fragment = url.substringAfter('#', missingDelimiterValue = "")
+    if (fragment.isBlank()) return emptyMap()
+
+    return try {
+        val decoded = fragment.decodeURLPart()
+        val json = bridgeJson.parseToJsonElement(decoded)
+        when (json) {
+            is JsonObject -> json.entries.associate { (key, element) ->
+                key to when (element) {
+                    is JsonPrimitive -> if (element.isString) element.content else element.toString()
+                    else -> element.toString()
+                }
+            }
+            else -> emptyMap()
+        }
+    } catch (_: Exception) {
+        emptyMap()
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/config/bridge/BridgeModels.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/config/bridge/BridgeModels.kt
@@ -1,0 +1,32 @@
+package coredevices.pebble.config.bridge
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Internal JSON serializer used by the bridge. Lenient to tolerate config pages that
+ * send numbers/strings loosely.
+ */
+val bridgeJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    encodeDefaults = false
+}
+
+@Serializable
+data class FetchRequest(
+    val url: String,
+    val method: String = "GET",
+    val headers: Map<String, String> = emptyMap(),
+    val body: String? = null,
+    val timeout: Long = 30_000,
+)
+
+@Serializable
+data class FetchResponse(
+    val ok: Boolean,
+    val status: Int,
+    val statusText: String,
+    val headers: Map<String, String>,
+    val body: String,
+)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerAppScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerAppScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.LocationSearching
 import androidx.compose.material.icons.filled.PlayCircle
 import androidx.compose.material.icons.filled.VerticalAlignTop
+import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.outlined.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.AlertDialog
@@ -901,18 +902,21 @@ fun AppCapability.icon(): ImageVector = when (this) {
     AppCapability.Health -> Icons.Default.HealthAndSafety
     AppCapability.Location -> Icons.Default.LocationSearching
     AppCapability.Timeline -> Icons.Default.LocationOn
+    AppCapability.NetworkBridge -> Icons.Default.Wifi
 }
 
 fun AppCapability.name(): String = when (this) {
     AppCapability.Health -> "Health"
     AppCapability.Location -> "Location"
     AppCapability.Timeline -> "Timeline"
+    AppCapability.NetworkBridge -> "Network Bridge"
 }
 
 fun AppCapability.description(): String = when (this) {
     AppCapability.Health -> "Can access health data"
     AppCapability.Location -> "Can access location"
     AppCapability.Timeline -> "Can create timeline pins"
+    AppCapability.NetworkBridge -> "Can make network requests from the config page"
 }
 
 suspend fun LibPebble.launchApp(
@@ -1005,6 +1009,7 @@ suspend fun CommonApp.showSettings(
                     PebbleRoutes.WatchappSettingsRoute(
                         watchIdentifier = watch.identifier.asString,
                         title = title,
+                        bridgeEnabled = capabilities.contains(AppCapability.NetworkBridge),
                     )
                 )
             }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PebbleRoutes.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PebbleRoutes.kt
@@ -31,6 +31,7 @@ object PebbleRoutes {
     data class WatchappSettingsRoute(
         val watchIdentifier: String,
         val title: String,
+        val bridgeEnabled: Boolean = false,
     ) : CoreRoute
 
     @Serializable
@@ -298,6 +299,7 @@ fun NavGraphBuilder.addPebbleRoutes(
             coreNav = coreNav,
             watchIdentifier = route.watchIdentifier,
             title = route.title,
+            bridgeEnabled = route.bridgeEnabled,
         )
     }
     composable<PebbleRoutes.ContactDeveloperRoute> {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.kt
@@ -21,9 +21,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import co.touchlab.kermit.Logger
+import coredevices.pebble.config.bridge.parseBridgeConfigFromUrlHash
 import com.multiplatform.webview.request.RequestInterceptor
 import com.multiplatform.webview.request.WebRequest
 import com.multiplatform.webview.request.WebRequestInterceptResult
@@ -65,7 +67,10 @@ internal object WatchappSettingsUrlCache {
 }
 internal expect fun webViewFactory(
     params: WebViewFactoryParam,
-    uuid: Uuid
+    uuid: Uuid,
+    bridgeEnabled: Boolean,
+    bridgeConfig: Map<String, String>,
+    onBridgeClose: (String) -> Unit,
 ): NativeWebView
 
 internal expect suspend fun restoreLocalStorage(webView: NativeWebView)
@@ -79,14 +84,17 @@ fun WatchappSettingsScreen(
     coreNav: CoreNav,
     watchIdentifier: String,
     title: String,
+    bridgeEnabled: Boolean,
 ) {
     val url = remember(watchIdentifier) {
         normalizeWatchappSettingsUrl(WatchappSettingsUrlCache.get(watchIdentifier) ?: "")
     }
+    val bridgeConfig = remember(url) { parseBridgeConfigFromUrlHash(url) }
     DisposableEffect(watchIdentifier) {
         onDispose { WatchappSettingsUrlCache.remove(watchIdentifier) }
     }
     Box(modifier = Modifier.background(MaterialTheme.colorScheme.background)) {
+        val scope = rememberCoroutineScope()
         val libPebble = rememberLibPebble()
         val pkjsSessionFlow = remember(watchIdentifier) {
             libPebble.watches
@@ -169,11 +177,23 @@ fun WatchappSettingsScreen(
             }
         ) { paddingValues ->
             pkjsSession?.uuid?.let { uuid ->
+                val onBridgeClose = remember(pkjsSession) {
+                    { returnValueJson: String ->
+                        runCatching { state.nativeWebView }.getOrNull()?.let { persistLocalStorage(it) }
+                        pkjsSession?.triggerOnWebviewClosed(returnValueJson) ?: run {
+                            logger.w { "No PKJS session found for $watchIdentifier, cannot handle bridge close" }
+                        }
+                        scope.launch {
+                            coreNav.goBack()
+                        }
+                        Unit
+                    }
+                }
                 WebView(
                     state = state,
                     modifier = Modifier.fillMaxSize().padding(paddingValues),
                     navigator = navigator,
-                    factory = { webViewFactory(it, uuid) }
+                    factory = { webViewFactory(it, uuid, bridgeEnabled, bridgeConfig, onBridgeClose) }
                 )
             }
         }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.kt
@@ -147,7 +147,7 @@ fun WatchappSettingsScreen(
         }
         val navigator = rememberWebViewNavigator(requestInterceptor = interceptor)
         LaunchedEffect(state.loadingState) {
-            if (state.loadingState is LoadingState.Loading) {
+            if (state.loadingState is LoadingState.Finished) {
                 logger.d { "Page load finished, applying shims" }
                 val nativeWebView = runCatching { state.nativeWebView }.getOrNull() ?: return@LaunchedEffect
                 restoreLocalStorage(nativeWebView)

--- a/pebble/src/iosMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.ios.kt
+++ b/pebble/src/iosMain/kotlin/coredevices/pebble/ui/WatchappSettingsScreen.ios.kt
@@ -14,7 +14,13 @@ import platform.WebKit.WKWebsiteDataStore
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalForeignApi::class)
-internal actual fun webViewFactory(params: WebViewFactoryParam, uuid: Uuid): NativeWebView =
+internal actual fun webViewFactory(
+    params: WebViewFactoryParam,
+    uuid: Uuid,
+    bridgeEnabled: Boolean,
+    bridgeConfig: Map<String, String>,
+    onBridgeClose: (String) -> Unit,
+): NativeWebView =
     defaultWebViewFactory(params).apply {
         if (available(OS.Ios to OSVersion(17))) {
             configuration.websiteDataStore =


### PR DESCRIPTION
This PR introduces a native Android bridge (`PebbleBridge`) that lets watchapp config pages running in the mobile app’s WebView access capabilities that are normally blocked by WebView sandboxing, CORS, mixed-content rules, or JavaScript restrictions. See https://github.com/coredevices/mobileapp/issues/301 for details.

When a watchapp declares the `config_network_bridge` capability, its config page receives a `window.pebbleBridge` object that delegates work to the native side. This allows a config page to:

- **Fetch from any HTTP/HTTPS endpoint** (`window.pebbleBridge.fetch`) — including local or self-hosted services that would otherwise be unreachable from a mobile WebView.
- **Open WebSocket connections** (`window.pebbleBridge.WebSocket`) — for streaming live data without WebSocket CORS issues.
- **Persist small amounts of data securely** (`window.pebbleBridge.storage`) — using the app’s encrypted storage instead of `localStorage`, which is not shared across sessions or reliable in a WebView.
- **Close the config page and return data to the watchapp** (`window.pebbleBridge.close`) — replacing the legacy `pebblejs://close#` URL scheme.

The bridge is opt-in per watchapp and only activates when the app declares the `config_network_bridge` capability, so existing watchapps are unaffected.

**Example use cases**

- A **Home Assistant client** config page that queries the HA REST API and WebSocket directly, populates an entity picker, and returns selected entities to the watchapp — all without requiring the watchapp itself to proxy the data. Effectively this is the purpose of h this PR. I am working on extending https://github.com/skylord123/pebble-home-assistant-ws for this (see https://github.com/caco3/pebble-home-assistant-ws/pull/4)
- A **weather watchapp** that fetches forecast data from a provider API and lets the user pick a location or unit system before returning the choice to the watch.

For easy testing, I created a minimal demo watchapp, see https://github.com/caco3/bridge-demo. It  demonstrates internet access through the config page.

## Key changes
- Added `NetworkBridge` (`config_network_bridge`) capability detection in `LockerAppScreen` and `PebbleRoutes`.
- Added a `bridgeEnabled` flag to `WatchappSettingsRoute` and passed it into `WatchappSettingsScreen`.
- Implemented [PebbleBridgeManager](cci:2://file:///home/gruinelli/CascadeProjects/mobileapp-bridge/pebble/src/androidMain/kotlin/coredevices/pebble/config/bridge/PebbleBridgeManager.kt:28:0-229:1), which registers `PebbleBridgeNativeInterface` on the WebView and injects a JS shim that creates `window.pebbleBridge`.
- Implemented native bridge APIs:
  - [fetch(url, options)](cci:1://file:///home/gruinelli/CascadeProjects/pebble-home-assistant-ws/config/bridge-shim.js:94:8-109:9) — HTTP via Ktor/OkHttp
  - `WebSocket(url, protocols)` — WebSocket via Ktor with message/close/error forwarding
  - `storage.get/set/remove` — Android `EncryptedSharedPreferences`
  - [close(returnValue)](cci:1://file:///home/gruinelli/CascadeProjects/pebble-home-assistant-ws/config/bridge-shim.js:128:8-130:9) — closes the config page and returns data to the app
- Added `BridgeConfigParser` to read config values from the URL hash fragment.
- Added `BridgeModels`, `BridgeFetch`, `BridgeStorage`, and [BridgeWebSocket](cci:1://file:///home/gruinelli/CascadeProjects/pebble-home-assistant-ws/config/bridge-shim.js:45:4-85:5) modules.
- Updated the iOS `webViewFactory` signature for source compatibility (**no iOS implementation yet**).

## Backward compatibility
Apps that do not declare `config_network_bridge` see no change.

## Documentation

See https://github.com/coredevices/sdk-docs/pull/17

###
High-level architecture
```
┌──────────────────────────────────────────────┐
│  Watch app config page (HTML/JS)             │
│  window.pebbleBridge.fetch(...)              │
│  window.pebbleBridge.WebSocket(...)          │
│  window.pebbleBridge.storage.get/set(...)    │
└──────────────────────────────────────────────┘
                       │
                       ▼
┌──────────────────────────────────────────────┐
│  JS shim (assets/bridge-shim.js)             │
│  Creates Promise-based API from native       │
└──────────────────────────────────────────────┘
                       │
                       ▼
┌──────────────────────────────────────────────┐
│  PebbleBridgeManager (Android)               │
│  - Shared Ktor/OkHttp HttpClient             │
│  - BridgeFetch, BridgeWebSocket              │
│  - BridgeStorage (EncryptedSharedPreferences)│
│  - PebbleBridgeNativeInterface (@JS)         │
└──────────────────────────────────────────────┘
                       │
      ┌────────────────┼────────────────┐
      ▼                ▼                ▼
  Ktor/OkHttp     Ktor/OkHttp     EncryptedShared
  fetch           WebSocket         Preferences
```

## Notes
- iOS support is intentionally out of scope; the iOS factory signature was updated only to keep the project compiling. I don't have access to iOS thus am unable to implement and test it for iOS.
- No public API changes outside the Pebble module.
- The code was generated using AI. My Kotlin skills are very limited, but I reviewed it am confident that it is ok.