### PR TITLE
RFC: sync Respect Phone DND to the watch (companion half)

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
@@ -177,6 +177,9 @@ sealed interface WatchPref<T> {
     fun castParent(parent: WatchPreference<*>): WatchPreference<T> = parent as WatchPreference<T>
     val isDebugSetting: Boolean
 
+    // Syncable but not rendered as its own settings row (e.g. driven by another toggle).
+    val userVisible: Boolean get() = true
+
     companion object {
         fun enumeratePrefs(): List<WatchPref<*>> = BoolWatchPref.entries
             .plus(QuicklaunchWatchPref.entries)
@@ -195,6 +198,7 @@ enum class BoolWatchPref(
     override val defaultValue: Boolean,
     override val isDebugSetting: Boolean = false,
     override val description: String? = null,
+    override val userVisible: Boolean = true,
 ) : WatchPref<Boolean> {
     TimezoneSourceIsManual("timezoneSource", "Timezone configured manually", false, description = "Manually configure a time zone on the watch (instead of automatcially using the time zone of the phone)"),
     Clock24h("clock24h", "24h clock", false),
@@ -209,6 +213,8 @@ enum class BoolWatchPref(
     AlternativeNotificationStyle("notifDesignStyle", "Alternative notification banner Style (B/W watches)", false),
     NotificationVibeDelay("notifVibeDelay", "Delay Notification Vibration", true, description = "Delay notification vibration until the notification is visible (after animations)"),
     NotificationBacklight("notifBacklight", "Notifications - Backlight", true, description = "Turn on the backlight when a notification arrives"),
+    // Synced firmware pref; the phone-side toggle is the UI control (userVisible = false).
+    RespectPhoneDnd("notifRespectPhoneSilence", "Respect Phone Do Not Disturb", false, userVisible = false),
     MenuScrollWrapAround("menuScrollWrapAround", "Menu Scrolling - Wrap Around", false, description = "Up button will go to the bottom of menus"),
     QuietTimeMotionBacklight("dndMotionBacklight", "Quiet Time - Motion Backlight", true, description = "Enable motion backlight during Quiet Time"),
     QuietTimeAutoDismiss("dndAutoDismiss", "Quiet Time - Auto Dismiss", false, description = "When notifications are shown in Quiet Time, automatically dismiss them instead of leaving them on-screen"),

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/blobdb/Timeline.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/blobdb/Timeline.kt
@@ -204,6 +204,13 @@ class TimelineItem(
         PERSIST_QUICK_VIEW(5),
 
         /**
+         * Firmware delivers the notification quietly (no popup/vibration/backlight) but still
+         * stores and lists it. Intended to carry the phone's Do Not Disturb / Focus state;
+         * nothing sets it yet (the emit path is a maintainer decision, see the PR).
+         */
+        SILENT(6),
+
+        /**
          * Marks a notification as read (dismisses if visible, and removes actions).
          */
         STATE_READ(12),

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/packets/blobdb/TimelineFlagSilentTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/packets/blobdb/TimelineFlagSilentTest.kt
@@ -1,0 +1,15 @@
+package io.rebble.libpebblecommon.packets.blobdb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TimelineFlagSilentTest {
+    @Test
+    fun silentFlagIsWireBit6() {
+        assertEquals(6, TimelineItem.Flag.SILENT.value)
+        assertEquals(
+            0x40u.toUShort(),
+            TimelineItem.Flag.makeFlags(listOf(TimelineItem.Flag.SILENT)),
+        )
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -50,7 +50,7 @@ fun watchPrefs(): List<SettingsItem> {
     val settings by libPebble.watchPrefs.collectAsState(emptyList())
     val quickLaunchOptions = quickLaunchOptions(libPebble)
     val mapped = remember(settings, quickLaunchOptions) {
-        settings.map { item ->
+        settings.filter { it.pref.userVisible }.map { item ->
             when (val pref = item.pref) {
                 is BoolWatchPref -> booleanPref(pref.castParent(item), libPebble)
                 is EnumWatchPref -> enumPref(pref.castParent(item), libPebble)
@@ -67,7 +67,7 @@ fun watchPrefs(): List<SettingsItem> {
         title = "Reset To Defaults?",
         text = "Reset all settings to defaults",
         onConfirm = {
-            settings.forEach { setting ->
+            settings.filter { it.pref.userVisible }.forEach { setting ->
                 if (setting.value != setting.pref.defaultValue) {
                     @Suppress("UNCHECKED_CAST")
                     val pref = setting.pref as WatchPref<Any?>
@@ -131,6 +131,7 @@ fun WatchPref<*>.section(): Section = when (this) {
     BoolWatchPref.AlternativeNotificationStyle -> Section.Notifications
     BoolWatchPref.NotificationVibeDelay -> Section.Notifications
     BoolWatchPref.NotificationBacklight -> Section.Notifications
+    BoolWatchPref.RespectPhoneDnd -> Section.Notifications
     NumberWatchPref.NotificationTimeoutMs -> Section.Notifications
     BoolWatchPref.MenuScrollWrapAround -> Section.Display
     EnumWatchPref.MenuScrollVibe -> Section.Display

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -151,6 +151,8 @@ import dev.gitlive.firebase.crashlytics.crashlytics
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.KnownPebbleDevice
+import io.rebble.libpebblecommon.database.dao.WatchPreference
+import io.rebble.libpebblecommon.database.entity.BoolWatchPref
 import io.rebble.libpebblecommon.database.entity.HRMonitoringInterval
 import io.rebble.libpebblecommon.database.entity.HealthGender
 import io.rebble.libpebblecommon.js.PKJSApp
@@ -703,7 +705,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                 ),
                 basicSettingsToggleItem(
                     title = "Respect Phone Do Not Disturb",
-                    description = "Notifications won't be sent to watch if phone is in Do Not Disturb mode (unless configured for that app/person in phone settings)",
+                    description = "When your phone is in Do Not Disturb / Focus, notifications it silences won't alert your watch (unless configured for that app/person in phone settings)",
                     topLevelType = TopLevelType.Phone,
                     section = Section.Notifications,
                     checked = libPebbleConfig.notificationConfig.respectDoNotDisturb,
@@ -715,8 +717,10 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                                 )
                             )
                         )
+                        // Mirror to the synced firmware pref (iOS enforces via ANCS).
+                        libPebble.setWatchPref(WatchPreference(BoolWatchPref.RespectPhoneDnd, it))
                     },
-                    show = { pebbleFeatures.supportsNotificationFiltering() },
+                    show = { true },
                 ),
                 SettingsItem(
                     title = "Vibration Pattern",


### PR DESCRIPTION
> **Paired PR:** the firmware half lives in [coredevices/PebbleOS#1772](https://github.com/coredevices/PebbleOS/pull/1772) (branch `rfc/phone-dnd-silent`) — it reads the ANCS silent flag, honours the wire `SILENT` bit platform-neutrally, and enforces quiet delivery when the synced `notifRespectPhoneSilence` pref is on. Each PR stands alone: firmware without this app change is inert; this app change without the firmware syncs a pref no watch reads.
>
> **Not compiled:** this machine has no JDK 17 / Android SDK, so the change was verified by manual compile-correctness passes (property/interface threading, exhaustive `when`s, signatures, wire encoding) but has NOT been built. Build + run before treating as working code.

## What this does

The [firmware half](https://github.com/coredevices/PebbleOS/pull/1772) honors a per-notification "silent" wire flag (bit 6 of the TimelineItem flags byte) and a syncable watch pref `notifRespectPhoneSilence`: when the pref is on, silent-flagged notifications get quiet delivery — stored and listed, no popup/vibration/backlight. This PR is the minimal app side that turns it on, **reusing the existing toggle instead of adding a second one**.

**The single control is the existing "Respect Phone Do Not Disturb" toggle** (Phone → Notifications). It was Android-only — gated on notification-filtering support, which iOS lacks because ANCS delivers notifications straight to the watch, bypassing the app. This PR:
- un-gates that one toggle so it shows on **both** platforms, and
- on change, mirrors it to a **hidden** synced watch pref `notifRespectPhoneSilence` — a `BoolWatchPref` with `userVisible = false`, so it is the firmware key and rides the existing watch-pref sync, but renders **no row of its own** (no duplicate toggle).

**iOS** — the app can't see the notification stream (ANCS goes phone→watch directly), so enforcement is firmware-side ([coredevices/PebbleOS#1772](https://github.com/coredevices/PebbleOS/pull/1772)); toggling just syncs the pref and the firmware acts on the ANCS silent bit.

**Android** — unchanged: the toggle still writes the existing `respectDoNotDisturb` config (the local-drop behaviour), and additionally syncs the pref, which is a harmless no-op there. See the next section for why the Android *behaviour* is deliberately left as-is.

This PR also declares `TimelineItem.Flag.SILENT(6)` — the wire-protocol counterpart of the firmware header bit — so the contract is documented in one place, even though nothing in this PR emits it.

## ⚖️ The Android wiring is a maintainer decision — this PR deliberately does NOT change Android

On Android the app *is* in the notification path, so unlike iOS it can act on DND itself. What should it do with a notification the phone delivered silently (DND/Focus)? Two defensible answers, and **which one ships is your call — this PR takes neither on Android, it leaves the status quo in place**:

**Option A — drop (status quo, what this PR keeps).** The existing `respectDoNotDisturb` toggle doesn't forward DND-suppressed notifications; they never reach the watch. Pros: watch stays clean, zero new moving parts, no firmware dependency. Cons: the notification is *gone* from the watch — it exists in the phone's shade but leaves no trace on the wrist; and it diverges from what the firmware currently does on iOS (lists it silently). That divergence is a design choice, not a platform limit — the firmware could equally discard silent notifications on iOS instead of listing them — but as written, iOS lists and Android drops.

**Option B — forward-but-quiet (NOT implemented here).** The app would forward the notification tagged with `SILENT`; the firmware stores and lists it without alerting. Pros: the watch stays a complete mirror of the phone's list, just without the buzz — identical to iOS, and matches how the phone itself treats DND (deliver quietly, not discard). Cons: changes what existing Android users see (notifications that used to vanish would appear, silently); on old firmware that ignores bit 6 they would arrive *alerting*.

**My preference: Option B (keep them on the watch).** I think keeping the notifications on the watch is the more correct behaviour — they can still be read, they just don't interrupt while DND is on. That mirrors the phone itself, where DND'd notifications stay visible in the shade rather than being discarded; dropping them on the watch throws away information the user may still want. I've left this PR on the conservative status quo (Option A) rather than change Android behaviour unilaterally, but my vote is Option B on both platforms.

The only Android-relevant addition here is the `SILENT(6)` wire-flag *definition*, so that if maintainers later choose Option B it needs no protocol change — just the emit path (set the flag when `matchesInterruptionFilter()` is false, per-notification, so Focus per-sender exceptions still alert).

## Tests

- `TimelineFlagSilentTest` (commonTest): `TimelineItem.Flag.SILENT.value == 6` and `makeFlags(listOf(SILENT))` emits bit 6 (`0x40`).

Not run locally (no toolchain) — see the warning at the top.

## Known trade-offs

- **Old firmware + new pref:** on iOS, enabling the toggle while running firmware that doesn't understand the pref simply does nothing (the firmware ignores an unknown synced pref). No misbehaviour — the feature just stays off until the firmware half ships.
- **No reverse sync:** the toggle's checked state reads the `respectDoNotDisturb` config and its handler mirrors that value to the synced pref, so the two stay consistent from the UI (reset-to-defaults also skips the hidden pref). Nothing reads the pref back into the config, so they could only diverge if something wrote the pref watch-side independently — a path that doesn't exist today (the pref has no watch UI). Noted for completeness.