### PR TITLE
Add watch charge limit setting

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/RoomTypeConverters.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/RoomTypeConverters.kt
@@ -182,7 +182,13 @@ class RoomTypeConverters {
 
     @TypeConverter
     fun StringToCapabilitySet(value: String): Set<ProtocolCapsFlag> {
-        return json.decodeFromString(value)
+        val known = ProtocolCapsFlag.entries.associateBy { it.name }
+        return json.decodeFromString<List<String>>(value).mapNotNull { name ->
+            known[name] ?: run {
+                logger.w { "Ignoring unknown watch capability: $name" }
+                null
+            }
+        }.toSet()
     }
 
     @TypeConverter

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/HealthSettings.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/HealthSettings.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlin.time.Clock
 import kotlin.time.Instant
-import kotlin.time.Instant.Companion.DISTANT_PAST
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -88,21 +87,8 @@ private val json = Json { ignoreUnknownKeys = true }
 // ActivityHRMSettings struct grew in firmware:
 //   v4.9.146: added uint8_t measurement_interval (1 → 2 bytes)
 //   v4.9.150: added bool activity_tracking_enabled  (2 → 3 bytes)
-private val FW_HRM_MEASUREMENT_INTERVAL = fwSentinel(4, 9, 146)
-private val FW_HRM_ACTIVITY_TRACKING = fwSentinel(4, 9, 150)
-
-private fun fwSentinel(major: Int, minor: Int, patch: Int) = FirmwareVersion(
-    stringVersion = "v$major.$minor.$patch",
-    timestamp = DISTANT_PAST,
-    major = major,
-    minor = minor,
-    patch = patch,
-    suffix = null,
-    gitHash = "",
-    isRecovery = false,
-    isDualSlot = false,
-    isSlot0 = false,
-)
+private val FW_HRM_MEASUREMENT_INTERVAL = FirmwareVersion.sentinel(4, 9, 146)
+private val FW_HRM_ACTIVITY_TRACKING = FirmwareVersion.sentinel(4, 9, 150)
 
 fun HealthSettingsEntryDao.getWatchSettings(): Flow<HealthSettings> {
     val activityPrefsFlow= getEntryFlow(KEY_ACTIVITY_PREFERENCES).map {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
@@ -14,6 +14,7 @@ import io.rebble.libpebblecommon.database.dao.ValueParams
 import io.rebble.libpebblecommon.database.dao.WatchPreference
 import io.rebble.libpebblecommon.database.entity.QuickLaunchSetting.Companion.toJson
 import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
 import io.rebble.libpebblecommon.packets.blobdb.TimelineAttribute
 import io.rebble.libpebblecommon.packets.blobdb.TimelineItem.Attribute
 import io.rebble.libpebblecommon.services.blobdb.DbWrite
@@ -66,6 +67,12 @@ data class WatchPrefItem(
         val type = WatchPref.from(id)
         if (type == null) {
             logger.w { "Don't know how to encode watch pref key: $id" }
+            return null
+        }
+        if (id == EnumWatchPref.ChargeLimit.id &&
+            !params.capabilities.contains(ProtocolCapsFlag.SupportsChargeLimit)
+        ) {
+            logger.d { "Watch does not support a charge limit" }
             return null
         }
         logger.v { "trying to insert watch pref to watch blobdb: $id / $value" }
@@ -399,6 +406,21 @@ enum class WatchLanguage(override val code: UByte, override val displayName: Str
     Polish(9u, "Polski"),
 }
 
+// Matches CHARGE_LIMIT_PCT_* in pebble-firmware:include/pbl/services/battery/battery_charge_limit.h.
+enum class ChargeLimitLevel(override val code: UByte, override val displayName: String) : WatchPrefEnum {
+    Off(0u, "Off"),
+    Limit50(50u, "50%"),
+    Limit55(55u, "55%"),
+    Limit60(60u, "60%"),
+    Limit65(65u, "65%"),
+    Limit70(70u, "70%"),
+    Limit75(75u, "75%"),
+    Limit80(80u, "80%"),
+    Limit85(85u, "85%"),
+    Limit90(90u, "90%"),
+    Limit95(95u, "95%"),
+}
+
 enum class EnumWatchPref(
     override val id: String,
     override val displayName: String,
@@ -519,6 +541,22 @@ enum class EnumWatchPref(
         defaultValue = WatchLanguage.Custom,
         options = WatchLanguage.entries,
     ),
+    ChargeLimit(
+        id = "chargeLimitPct",
+        displayName = "Charge Limit",
+        description = "Limit charging to extend your battery's lifespan",
+        defaultValue = ChargeLimitLevel.Off,
+        options = ChargeLimitLevel.entries,
+    ) {
+        override fun decodeValue(value: String): WatchPrefEnum {
+            val code = value.toUByteOrNull() ?: return defaultValue
+            if (code > ChargeLimitLevel.Limit95.code) return ChargeLimitLevel.Off
+            return ChargeLimitLevel.entries
+                .filter { it != ChargeLimitLevel.Off && it.code <= code }
+                .maxByOrNull { it.code }
+                ?: ChargeLimitLevel.Off
+        }
+    },
     ;
 
     override val type = WatchPrefType.TypeUInt8

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
@@ -16,6 +16,7 @@ import io.rebble.libpebblecommon.database.entity.QuickLaunchSetting.Companion.to
 import io.rebble.libpebblecommon.metadata.WatchType
 import io.rebble.libpebblecommon.packets.blobdb.TimelineAttribute
 import io.rebble.libpebblecommon.packets.blobdb.TimelineItem.Attribute
+import io.rebble.libpebblecommon.services.FirmwareVersion
 import io.rebble.libpebblecommon.services.blobdb.DbWrite
 import io.rebble.libpebblecommon.structmapper.SBoolean
 import io.rebble.libpebblecommon.structmapper.SFixedList
@@ -66,6 +67,11 @@ data class WatchPrefItem(
         val type = WatchPref.from(id)
         if (type == null) {
             logger.w { "Don't know how to encode watch pref key: $id" }
+            return null
+        }
+        val minFirmwareVersion = type.minFirmwareVersion
+        if (minFirmwareVersion != null && params.firmwareVersion < minFirmwareVersion) {
+            logger.d { "Watch firmware ${params.firmwareVersion.stringVersion} predates $id" }
             return null
         }
         logger.v { "trying to insert watch pref to watch blobdb: $id / $value" }
@@ -176,6 +182,7 @@ sealed interface WatchPref<T> {
     fun encodeValue(value: T): String
     fun castParent(parent: WatchPreference<*>): WatchPreference<T> = parent as WatchPreference<T>
     val isDebugSetting: Boolean
+    val minFirmwareVersion: FirmwareVersion? get() = null
 
     companion object {
         fun enumeratePrefs(): List<WatchPref<*>> = BoolWatchPref.entries
@@ -407,6 +414,21 @@ enum class WatchLanguage(override val code: UByte, override val displayName: Str
     Polish(9u, "Polski"),
 }
 
+// Matches CHARGE_LIMIT_PCT_* in pebble-firmware:include/pbl/services/battery/battery_charge_limit.h.
+enum class ChargeLimitLevel(override val code: UByte, override val displayName: String) : WatchPrefEnum {
+    Off(0u, "Off"),
+    Limit50(50u, "50%"),
+    Limit55(55u, "55%"),
+    Limit60(60u, "60%"),
+    Limit65(65u, "65%"),
+    Limit70(70u, "70%"),
+    Limit75(75u, "75%"),
+    Limit80(80u, "80%"),
+    Limit85(85u, "85%"),
+    Limit90(90u, "90%"),
+    Limit95(95u, "95%"),
+}
+
 enum class EnumWatchPref(
     override val id: String,
     override val displayName: String,
@@ -414,6 +436,7 @@ enum class EnumWatchPref(
     val options: List<WatchPrefEnum>,
     override val isDebugSetting: Boolean = false,
     override val description: String? = null,
+    override val minFirmwareVersion: FirmwareVersion? = null,
 ) : WatchPref<WatchPrefEnum> {
     TextSize("textStyle", "Text Size", ContentSize.Default, ContentSize.entries),
     NotificationFilter(
@@ -534,6 +557,23 @@ enum class EnumWatchPref(
         defaultValue = WatchLanguage.Custom,
         options = WatchLanguage.entries,
     ),
+    ChargeLimit(
+        id = "chargeLimitPct",
+        displayName = "Charge Limit",
+        description = "Limit charging to extend your battery's lifespan",
+        defaultValue = ChargeLimitLevel.Off,
+        options = ChargeLimitLevel.entries,
+        minFirmwareVersion = FirmwareVersion.sentinel(4, 37, 0),
+    ) {
+        override fun decodeValue(value: String): WatchPrefEnum {
+            val code = value.toUByteOrNull() ?: return defaultValue
+            if (code > ChargeLimitLevel.Limit95.code) return ChargeLimitLevel.Off
+            return ChargeLimitLevel.entries
+                .filter { it != ChargeLimitLevel.Off && it.code <= code }
+                .maxByOrNull { it.code }
+                ?: ChargeLimitLevel.Off
+        }
+    },
     ;
 
     override val type = WatchPrefType.TypeUInt8

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/System.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/System.kt
@@ -373,6 +373,7 @@ enum class ProtocolCapsFlag(val value: Int) {
     SupportsBlobDbVersion(22),
     SupportsSettingsSync(23),
     SupportsWeatherDbV4(24),
+    SupportsChargeLimit(25),
     ;
 
     companion object {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/SystemService.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/SystemService.kt
@@ -323,6 +323,19 @@ data class FirmwareVersion(
             )
         }
 
+        fun sentinel(major: Int, minor: Int, patch: Int) = FirmwareVersion(
+            stringVersion = "v$major.$minor.$patch",
+            timestamp = Instant.DISTANT_PAST,
+            major = major,
+            minor = minor,
+            patch = patch,
+            suffix = null,
+            gitHash = "",
+            isRecovery = false,
+            isDualSlot = false,
+            isSlot0 = false,
+        )
+
         fun FirmwareVersion.slot(): Int? = when {
             isDualSlot && isSlot0 -> 0
             isDualSlot && !isSlot0 -> 1

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/RoomTypeConvertersTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/RoomTypeConvertersTest.kt
@@ -1,0 +1,31 @@
+package io.rebble.libpebblecommon.database
+
+import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoomTypeConvertersTest {
+    private val converters = RoomTypeConverters()
+
+    @Test
+    fun capabilitySetRoundTrips() {
+        val capabilities = setOf(
+            ProtocolCapsFlag.SupportsAppRunStateProtocol,
+            ProtocolCapsFlag.SupportsWeatherApp,
+        )
+        assertEquals(
+            capabilities,
+            converters.StringToCapabilitySet(converters.CapabilitySetToString(capabilities)),
+        )
+    }
+
+    @Test
+    fun capabilitySetIgnoresUnknownNames() {
+        assertEquals(
+            setOf(ProtocolCapsFlag.SupportsWeatherApp),
+            converters.StringToCapabilitySet(
+                """["SupportsWeatherApp","SupportsSomethingFromTheFuture"]"""
+            ),
+        )
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitPrefTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitPrefTest.kt
@@ -1,0 +1,61 @@
+package io.rebble.libpebblecommon.database.entity
+
+import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChargeLimitPrefTest {
+    @Test
+    fun prefIdMatchesTheFirmwareSettingsKey() {
+        assertEquals("chargeLimitPct", EnumWatchPref.ChargeLimit.id)
+    }
+
+    @Test
+    fun capabilityUsesBitIndex25() {
+        assertEquals(25, ProtocolCapsFlag.SupportsChargeLimit.value)
+    }
+
+    @Test
+    fun decodesExactCodes() {
+        assertEquals(ChargeLimitLevel.Limit80, EnumWatchPref.ChargeLimit.decodeValue("80"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("0"))
+    }
+
+    @Test
+    fun decodesTheFirmwareRangeBoundaries() {
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("49"))
+        assertEquals(ChargeLimitLevel.Limit50, EnumWatchPref.ChargeLimit.decodeValue("50"))
+        assertEquals(ChargeLimitLevel.Limit95, EnumWatchPref.ChargeLimit.decodeValue("95"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("96"))
+    }
+
+    @Test
+    fun snapsOffStepValuesToTheStepBelow() {
+        assertEquals(ChargeLimitLevel.Limit80, EnumWatchPref.ChargeLimit.decodeValue("82"))
+        assertEquals(ChargeLimitLevel.Limit50, EnumWatchPref.ChargeLimit.decodeValue("54"))
+        assertEquals(ChargeLimitLevel.Limit90, EnumWatchPref.ChargeLimit.decodeValue("94"))
+    }
+
+    @Test
+    fun fallsBackToOffForValuesTheFirmwareRejects() {
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("30"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("96"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("garbage"))
+    }
+
+    @Test
+    fun encodesTheRawPercentCode() {
+        assertEquals("80", EnumWatchPref.ChargeLimit.encodeValue(ChargeLimitLevel.Limit80))
+        assertEquals("0", EnumWatchPref.ChargeLimit.encodeValue(ChargeLimitLevel.Off))
+    }
+
+    @Test
+    fun encodeDecodeRoundTripsEveryLevel() {
+        ChargeLimitLevel.entries.forEach { level ->
+            assertEquals(
+                level,
+                EnumWatchPref.ChargeLimit.decodeValue(EnumWatchPref.ChargeLimit.encodeValue(level))
+            )
+        }
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitPrefTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitPrefTest.kt
@@ -1,0 +1,55 @@
+package io.rebble.libpebblecommon.database.entity
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChargeLimitPrefTest {
+    @Test
+    fun prefIdMatchesTheFirmwareSettingsKey() {
+        assertEquals("chargeLimitPct", EnumWatchPref.ChargeLimit.id)
+    }
+
+    @Test
+    fun decodesExactCodes() {
+        assertEquals(ChargeLimitLevel.Limit80, EnumWatchPref.ChargeLimit.decodeValue("80"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("0"))
+    }
+
+    @Test
+    fun decodesTheFirmwareRangeBoundaries() {
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("49"))
+        assertEquals(ChargeLimitLevel.Limit50, EnumWatchPref.ChargeLimit.decodeValue("50"))
+        assertEquals(ChargeLimitLevel.Limit95, EnumWatchPref.ChargeLimit.decodeValue("95"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("96"))
+    }
+
+    @Test
+    fun snapsOffStepValuesToTheStepBelow() {
+        assertEquals(ChargeLimitLevel.Limit80, EnumWatchPref.ChargeLimit.decodeValue("82"))
+        assertEquals(ChargeLimitLevel.Limit50, EnumWatchPref.ChargeLimit.decodeValue("54"))
+        assertEquals(ChargeLimitLevel.Limit90, EnumWatchPref.ChargeLimit.decodeValue("94"))
+    }
+
+    @Test
+    fun fallsBackToOffForValuesTheFirmwareRejects() {
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("30"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("96"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("garbage"))
+    }
+
+    @Test
+    fun encodesTheRawPercentCode() {
+        assertEquals("80", EnumWatchPref.ChargeLimit.encodeValue(ChargeLimitLevel.Limit80))
+        assertEquals("0", EnumWatchPref.ChargeLimit.encodeValue(ChargeLimitLevel.Off))
+    }
+
+    @Test
+    fun encodeDecodeRoundTripsEveryLevel() {
+        ChargeLimitLevel.entries.forEach { level ->
+            assertEquals(
+                level,
+                EnumWatchPref.ChargeLimit.decodeValue(EnumWatchPref.ChargeLimit.encodeValue(level))
+            )
+        }
+    }
+}

--- a/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitValueTest.kt
+++ b/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitValueTest.kt
@@ -1,0 +1,55 @@
+package io.rebble.libpebblecommon.database.entity
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.database.asMillisecond
+import io.rebble.libpebblecommon.database.dao.ValueParams
+import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+private val FW_TEST = FirmwareVersion(
+    stringVersion = "v0.0.0",
+    timestamp = Instant.DISTANT_PAST,
+    major = 0,
+    minor = 0,
+    patch = 0,
+    suffix = null,
+    gitHash = "",
+    isRecovery = false,
+    isDualSlot = false,
+    isSlot0 = false,
+)
+
+class ChargeLimitValueTest {
+    private val item = WatchPrefItem(
+        id = EnumWatchPref.ChargeLimit.id,
+        value = "80",
+        timestamp = Instant.DISTANT_PAST.asMillisecond(),
+    )
+
+    private fun params(capabilities: Set<ProtocolCapsFlag>) = ValueParams(
+        WatchType.APLITE,
+        capabilities,
+        FW_TEST,
+        libPebbleConfigFlow = LibPebbleConfigFlow(MutableStateFlow(LibPebbleConfig())),
+    )
+
+    @Test
+    fun encodesWhenTheWatchSupportsChargeLimit() {
+        assertContentEquals(
+            ubyteArrayOf(80u),
+            item.value(params(setOf(ProtocolCapsFlag.SupportsChargeLimit))),
+        )
+    }
+
+    @Test
+    fun skippedWhenTheWatchLacksTheCapability() {
+        assertNull(item.value(params(emptySet())))
+    }
+}

--- a/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitValueTest.kt
+++ b/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitValueTest.kt
@@ -1,0 +1,71 @@
+package io.rebble.libpebblecommon.database.entity
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.database.asMillisecond
+import io.rebble.libpebblecommon.database.dao.ValueParams
+import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+private fun firmware(major: Int, minor: Int, patch: Int, suffix: String? = null) = FirmwareVersion(
+    stringVersion = "v$major.$minor.$patch" + (suffix?.let { "-$it" } ?: ""),
+    timestamp = Instant.fromEpochSeconds(1_757_000_000),
+    major = major,
+    minor = minor,
+    patch = patch,
+    suffix = suffix,
+    gitHash = "abc1234",
+    isRecovery = false,
+    isDualSlot = true,
+    isSlot0 = false,
+)
+
+class ChargeLimitValueTest {
+    private val item = WatchPrefItem(
+        id = EnumWatchPref.ChargeLimit.id,
+        value = "80",
+        timestamp = Instant.DISTANT_PAST.asMillisecond(),
+    )
+
+    private fun params(firmwareVersion: FirmwareVersion) = ValueParams(
+        WatchType.APLITE,
+        emptySet(),
+        firmwareVersion,
+        libPebbleConfigFlow = LibPebbleConfigFlow(MutableStateFlow(LibPebbleConfig())),
+    )
+
+    @Test
+    fun encodesOnTheFirstFirmwareThatShipsThePref() {
+        assertContentEquals(ubyteArrayOf(80u), item.value(params(firmware(4, 37, 0))))
+    }
+
+    @Test
+    fun encodesOnDevelopmentBuildsPastThatTag() {
+        assertContentEquals(ubyteArrayOf(80u), item.value(params(firmware(4, 37, 0, "9-gabc1234"))))
+    }
+
+    @Test
+    fun encodesOnLaterFirmware() {
+        assertContentEquals(ubyteArrayOf(80u), item.value(params(firmware(4, 38, 0))))
+    }
+
+    @Test
+    fun skippedOnFirmwareThatPredatesThePref() {
+        assertNull(item.value(params(firmware(4, 36, 2))))
+    }
+
+    @Test
+    fun prefsWithoutAMinimumVersionAreUnaffected() {
+        val clock24h = WatchPrefItem(
+            id = BoolWatchPref.Clock24h.id,
+            value = "1",
+            timestamp = Instant.DISTANT_PAST.asMillisecond(),
+        )
+        assertContentEquals(ubyteArrayOf(1u), clock24h.value(params(firmware(4, 0, 0))))
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/BatterySettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/BatterySettingsScreen.kt
@@ -47,6 +47,20 @@ private const val MOBILE_BATTERY_PATH = "/m/battery"
 
 @Composable
 fun BatterySettingsScreen(navBarNav: NavBarNav, topBarParams: TopBarParams) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        chargeLimitSettingsItem()?.Item()
+        Box(Modifier.weight(1f)) {
+            BatteryAnalyticsContent(navBarNav, topBarParams)
+        }
+    }
+}
+
+@Composable
+private fun BatteryAnalyticsContent(navBarNav: NavBarNav, topBarParams: TopBarParams) {
     val apiConfig = koinInject<CommonApiConfig>()
     val settings = koinInject<Settings>()
     val analyticsEnabled = settings.getBoolean(KEY_ENABLE_MEMFAULT_UPLOADS, true)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -67,8 +67,12 @@ fun watchPrefs(): List<SettingsItem> {
     val libPebble = rememberLibPebble()
     val settings by libPebble.watchPrefs.collectAsState(emptyList())
     val quickLaunchOptions = quickLaunchOptions(libPebble)
-    val mapped = remember(settings, quickLaunchOptions) {
-        settings.hidePresetManagedBacklightPrefs().map { item ->
+    val watches by libPebble.watches.collectAsState()
+    val supportsChargeLimit = watches.anySupportsChargeLimit()
+    val mapped = remember(settings, quickLaunchOptions, supportsChargeLimit) {
+        settings.hidePresetManagedBacklightPrefs().filterNot {
+            it.pref == EnumWatchPref.ChargeLimit && !supportsChargeLimit
+        }.map { item ->
             when (val pref = item.pref) {
                 is BoolWatchPref -> booleanPref(pref.castParent(item), libPebble)
                 is EnumWatchPref -> enumPref(pref.castParent(item), libPebble)
@@ -156,6 +160,20 @@ fun WatchPref<*>.section(): Section = when (this) {
     BoolWatchPref.QuietTimeAutoDismiss -> Section.QuietTime
     BoolWatchPref.MusicShowVolumeControls -> Section.Music
     BoolWatchPref.MusicShowProgressBar -> Section.Music
+    EnumWatchPref.ChargeLimit -> Section.Battery
+}
+
+@Composable
+internal fun chargeLimitSettingsItem(): SettingsItem? {
+    val libPebble = rememberLibPebble()
+    val config by libPebble.config.collectAsState()
+    val watches by libPebble.watches.collectAsState()
+    if (!config.watchConfig.enableWatchSettingsSync || !watches.anySupportsChargeLimit()) {
+        return null
+    }
+    val settings by libPebble.watchPrefs.collectAsState(emptyList())
+    val item = settings.firstOrNull { it.pref == EnumWatchPref.ChargeLimit } ?: return null
+    return enumPref(EnumWatchPref.ChargeLimit.castParent(item), libPebble)
 }
 
 private fun numberPref(item: WatchPreference<Long>, libPebble: LibPebble): SettingsItem {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -23,7 +23,9 @@ import io.rebble.libpebblecommon.SystemAppIDs.MOTION_BACKLIGHT_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.QUIET_TIME_TOGGLE_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.TIMELINE_FUTURE_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.TIMELINE_PAST_UUID
+import io.rebble.libpebblecommon.connection.KnownPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.connection.PebbleDevice
 import io.rebble.libpebblecommon.database.dao.WatchPreference
 import io.rebble.libpebblecommon.database.entity.BacklightPresetMode
 import io.rebble.libpebblecommon.database.entity.BoolWatchPref
@@ -36,8 +38,10 @@ import io.rebble.libpebblecommon.database.entity.RgbColorWatchPref
 import io.rebble.libpebblecommon.database.entity.WatchPref
 import io.rebble.libpebblecommon.database.entity.WatchPrefEnum
 import io.rebble.libpebblecommon.locker.AppType
+import io.rebble.libpebblecommon.services.FirmwareVersion
 import io.rebble.libpebblecommon.timeline.TimelineColor
 import kotlinx.coroutines.flow.map
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 // Snap the notification timeout slider to 30-second increments (20 stops across 0..600s)
@@ -66,8 +70,10 @@ fun watchPrefs(): List<SettingsItem> {
     val libPebble = rememberLibPebble()
     val settings by libPebble.watchPrefs.collectAsState(emptyList())
     val quickLaunchOptions = quickLaunchOptions(libPebble)
-    val mapped = remember(settings, quickLaunchOptions) {
-        settings.hidePresetManagedBacklightPrefs().map { item ->
+    val watches by libPebble.watches.collectAsState()
+    val firmwareVersions = remember(watches) { watches.knownFirmwareVersions() }
+    val mapped = remember(settings, quickLaunchOptions, firmwareVersions) {
+        settings.hidePresetManagedBacklightPrefs().filter { firmwareVersions.anySupports(it.pref) }.map { item ->
             when (val pref = item.pref) {
                 is BoolWatchPref -> booleanPref(pref.castParent(item), libPebble)
                 is EnumWatchPref -> enumPref(pref.castParent(item), libPebble)
@@ -157,6 +163,21 @@ fun WatchPref<*>.section(): Section = when (this) {
     BoolWatchPref.MusicShowVolumeControls -> Section.Music
     BoolWatchPref.MusicShowProgressBar -> Section.Music
     BoolWatchPref.MusicShowAlbumArt -> Section.Music
+    EnumWatchPref.ChargeLimit -> Section.Battery
+}
+
+@Composable
+internal fun chargeLimitSettingsItem(): SettingsItem? {
+    val libPebble = rememberLibPebble()
+    val config by libPebble.config.collectAsState()
+    val watches by libPebble.watches.collectAsState()
+    val firmwareVersions = remember(watches) { watches.knownFirmwareVersions() }
+    if (!config.watchConfig.enableWatchSettingsSync || !firmwareVersions.anySupports(EnumWatchPref.ChargeLimit)) {
+        return null
+    }
+    val settings by libPebble.watchPrefs.collectAsState(emptyList())
+    val item = settings.firstOrNull { it.pref == EnumWatchPref.ChargeLimit } ?: return null
+    return enumPref(EnumWatchPref.ChargeLimit.castParent(item), libPebble, controlOnLeft = true)
 }
 
 fun WatchPref<*>.topLevelType(): TopLevelType = when (this) {
@@ -164,6 +185,23 @@ fun WatchPref<*>.topLevelType(): TopLevelType = when (this) {
     EnumWatchPref.WindSpeed -> TopLevelType.Phone
     else -> TopLevelType.Watch
 }
+
+internal fun List<PebbleDevice>.knownFirmwareVersions(): Set<FirmwareVersion> =
+    filterIsInstance<KnownPebbleDevice>().mapNotNull { it.firmwareVersion() }.toSet()
+
+internal fun Set<FirmwareVersion>.anySupports(pref: WatchPref<*>): Boolean {
+    val minFirmwareVersion = pref.minFirmwareVersion ?: return true
+    return any { it >= minFirmwareVersion }
+}
+
+private fun KnownPebbleDevice.firmwareVersion(): FirmwareVersion? = FirmwareVersion.from(
+    tag = runningFwVersion,
+    isRecovery = false,
+    gitHash = "",
+    timestamp = Instant.DISTANT_PAST,
+    isDualSlot = false,
+    isSlot0 = false,
+)
 
 private fun numberPref(item: WatchPreference<Long>, libPebble: LibPebble): SettingsItem {
     val pref = item.pref as NumberWatchPref
@@ -281,7 +319,11 @@ private fun booleanPref(item: WatchPreference<Boolean>, libPebble: LibPebble): S
     )
 }
 
-private fun enumPref(item: WatchPreference<WatchPrefEnum>, libPebble: LibPebble): SettingsItem {
+private fun enumPref(
+    item: WatchPreference<WatchPrefEnum>,
+    libPebble: LibPebble,
+    controlOnLeft: Boolean = false,
+): SettingsItem {
     val pref = item.pref as EnumWatchPref
     return basicSettingsDropdownItem(
         id = pref.id,
@@ -296,6 +338,7 @@ private fun enumPref(item: WatchPreference<WatchPrefEnum>, libPebble: LibPebble)
         },
         itemText = { it.displayName },
         isDebugSetting = pref.isDebugSetting,
+        controlOnLeft = controlOnLeft,
     )
 }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -153,6 +153,7 @@ import dev.gitlive.firebase.crashlytics.crashlytics
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.KnownPebbleDevice
+import io.rebble.libpebblecommon.connection.PebbleDevice
 import io.rebble.libpebblecommon.database.entity.HRMonitoringInterval
 import io.rebble.libpebblecommon.database.entity.HealthGender
 import io.rebble.libpebblecommon.js.PKJSApp
@@ -225,6 +226,14 @@ enum class Section(val title: String, val icon: ImageVector) {
     Other("Other", Icons.Default.MoreHoriz), // watch only
     Diagnostics("Diagnostics", Icons.Default.Timeline),
     Debug("Debug", Icons.Default.BugReport),
+}
+
+internal fun List<PebbleDevice>.anySupportsSettingsSync(): Boolean = any {
+    it is KnownPebbleDevice && it.capabilities.contains(ProtocolCapsFlag.SupportsBlobDbVersion)
+}
+
+internal fun List<PebbleDevice>.anySupportsChargeLimit(): Boolean = any {
+    it is KnownPebbleDevice && it.capabilities.contains(ProtocolCapsFlag.SupportsChargeLimit)
 }
 
 fun Section.navigatesDirectlyTo(): NavBarRoute? = when (this) {
@@ -476,11 +485,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
     val watches by libPebble.watches.collectAsState(null)
     val watchesCastable = watches ?: return null
     val anyWatchSupportsSettingsSync = remember(watchesCastable) {
-        watchesCastable.any {
-            it is KnownPebbleDevice && it.capabilities.contains(
-                ProtocolCapsFlag.SupportsBlobDbVersion
-            )
-        }
+        watchesCastable.anySupportsSettingsSync()
     }
     val watchPrefs = watchPrefs()
     val coreAnalytics: CoreAnalytics = koinInject()

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
@@ -2665,6 +2666,8 @@ fun basicSettingsNumberFieldItem(
     },
 )
 
+private val LEADING_CONTROL_WIDTH = 48.dp
+
 fun <T> basicSettingsDropdownItem(
     id: String? = null,
     title: String,
@@ -2679,6 +2682,7 @@ fun <T> basicSettingsDropdownItem(
     show: () -> Boolean = { true },
     isDebugSetting: Boolean = false,
     extraSupportingContent: (@Composable () -> Unit)? = null,
+    controlOnLeft: Boolean = false,
 ) = SettingsItem(
     id = id,
     title = title,
@@ -2688,36 +2692,44 @@ fun <T> basicSettingsDropdownItem(
     show = show,
     isDebugSetting = isDebugSetting,
     item = {
+        val dropdown: @Composable () -> Unit = {
+            var expanded by remember { mutableStateOf(false) }
+            Box(
+                modifier = if (controlOnLeft) Modifier.width(LEADING_CONTROL_WIDTH) else Modifier,
+                contentAlignment = Alignment.Center,
+            ) {
+                TextButton(
+                    onClick = { expanded = true },
+                    contentPadding = if (controlOnLeft) PaddingValues(0.dp) else ButtonDefaults.TextButtonContentPadding,
+                ) {
+                    Text(
+                        text = itemText(selectedItem),
+                        modifier = Modifier.widthIn(max = 150.dp),
+                        maxLines = 1,
+                    )
+                }
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    items.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(itemText(option)) },
+                            onClick = {
+                                onItemSelected(option)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
         ListItem(
             headlineContent = {
                 Text(title)
             },
-            trailingContent = {
-                var expanded by remember { mutableStateOf(false) }
-                Box {
-                    TextButton(onClick = { expanded = true }) {
-                        Text(
-                            text = itemText(selectedItem),
-                            modifier = Modifier.widthIn(max = 150.dp),
-                            maxLines = 1,
-                        )
-                    }
-                    DropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false }
-                    ) {
-                        items.forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(itemText(option)) },
-                                onClick = {
-                                    onItemSelected(option)
-                                    expanded = false
-                                }
-                            )
-                        }
-                    }
-                }
-            },
+            leadingContent = if (controlOnLeft) dropdown else null,
+            trailingContent = if (controlOnLeft) null else dropdown,
             supportingContent = {
                 Row {
                     if (description != null) {


### PR DESCRIPTION
# Add watch charge limit setting

Adds a Charge Limit row to the Battery screen, backed by the `chargeLimitPct` watch pref introduced in coredevices/PebbleOS#1841. Capping charge below full is the usual way to slow lithium ageing, and the firmware side already enforces it. This is the phone-side control and the encoder that lets the value reach the watch at all.

| Light | Dark |
| --- | --- |
| ![Charge Limit in light mode](https://github.com/peblum/mobileapp/releases/download/pr-assets/charge-limit-light.png) | ![Charge Limit in dark mode](https://github.com/peblum/mobileapp/releases/download/pr-assets/charge-limit-dark.png) |

## Row layout

The value sits in the row's leading slot rather than the trailing one, in a slot the same width as the checkbox every boolean setting already uses, so the Battery screen's rows line up with each other. `basicSettingsDropdownItem` gains an opt-in `controlOnLeft`; every other screen keeps the trailing value it has today.

## Why an encoder is the substantive part

`WatchPrefItem.value()` looks the key up in `WatchPref.from(id)` and returns null for anything it does not recognise, so an unregistered pref is dropped before it reaches the blobdb insert. Without the `EnumWatchPref.ChargeLimit` entry the app logs `Don't know how to encode watch pref key: chargeLimitPct` and the write is silently discarded, which is what the shipping build does today. Registering the key is what makes the row do anything.

## Range handling

The pref is `Off` by default, then 50% to 95% in 5% steps, carried as `TypeUInt8`. The firmware accepts `0` or `50` to `95` and validates on sync and at boot, so the app must not emit anything else. It structurally cannot: `encodeValue` is the enum's own code, and the enum only defines those values.

Decoding is the direction that needs guarding, because it consumes whatever the watch or another client wrote. Off-step values snap down to the step below, and anything outside the accepted range reads as `Off`, which matches how the firmware would treat it. `ChargeLimitPrefTest` pins that behaviour, including the case where a nonzero value below 50 must not survive as a limit.

## Visibility

A watch pref can now declare a `minFirmwareVersion`, the same idea the HRM prefs already use inline. `WatchPrefItem.value()` skips the pref below that version so it is never sent to firmware that would reject the key, and the Battery screen and the watch settings list hide the row for the same watches. Prefs without a minimum behave exactly as before.

`ChargeLimit` is pinned to `v4.37.0`, the latest firmware tag at the time of writing, so builds from `main` that carry the firmware change qualify. It should move to the release that actually ships coredevices/PebbleOS#1841 once that is known. `ChargeLimitValueTest` covers the boundary on both sides and a pref without a minimum.

Written with AI assistance (Claude), and exercised on a Pixel 6 with a Pebble Time 2.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.

