### PR TITLE
Refresh relative timestamps when Index resumes

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/home/IndexFeedComponents.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/home/IndexFeedComponents.kt
@@ -107,11 +107,9 @@ import coredevices.ring.ui.theme.IndexTheme
 import coredevices.ring.ui.theme.IndexThemeHost
 import coredevices.ring.ui.theme.indexTextEntryStyle
 import coredevices.ring.ui.viewmodel.IndexFeedViewModel
-import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -128,6 +126,7 @@ internal fun IndexHeader(
     onQueryChange: (String) -> Unit,
     onStartSearch: () -> Unit,
     onCancelSearch: () -> Unit,
+    relativeTimeNow: Instant,
     trailingActions: @Composable (RowScope.() -> Unit)? = null,
 ) {
     val colors = IndexTheme.colors
@@ -211,7 +210,7 @@ internal fun IndexHeader(
                     softWrap = false,
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                 )
-                PulsingSyncHint(modifier = Modifier.weight(1f))
+                PulsingSyncHint(now = relativeTimeNow, modifier = Modifier.weight(1f))
             }
             IconButton(onClick = onStartSearch) {
                 Icon(Icons.Default.Search, "Search", tint = colors.onSurfaceVariant, modifier = Modifier.size(20.dp))
@@ -222,24 +221,14 @@ internal fun IndexHeader(
 }
 
 @Composable
-internal fun PulsingSyncHint(modifier: Modifier = Modifier) {
+internal fun PulsingSyncHint(now: Instant, modifier: Modifier = Modifier) {
     val colors = IndexTheme.colors
     val lastSyncedAt by koinInject<RingSync>().lastSyncedAt.collectAsState()
-
-    // Re-evaluate on a slow tick so the relative label ages ("just now" →
-    // "5m ago") and flips back to the pulsing prompt once the sync goes stale.
-    var now by remember { mutableStateOf(Clock.System.now()) }
-    LaunchedEffect(lastSyncedAt) {
-        while (true) {
-            now = Clock.System.now()
-            delay(1.minutes)
-        }
-    }
 
     val synced = lastSyncedAt
     if (synced != null && now - synced < SYNC_HINT_FRESH_WINDOW) {
         Text(
-            "Last synced ${relativeTime(synced)}",
+            "Last synced ${relativeTime(synced, now)}",
             color = colors.onSurfaceVariant,
             fontSize = 12.sp,
             letterSpacing = (-0.05).sp,
@@ -363,6 +352,7 @@ internal fun PeekStrip(
     peeks: List<IndexFeedViewModel.UiState.RecordingPeek>,
     onOpenRecording: (LocalRecording) -> Unit,
     onRetryRecording: (LocalRecording, RecordingEntryEntity) -> Unit,
+    relativeTimeNow: Instant,
 ) {
     val visiblePeeks = peeks.take(5)
     val firstId = visiblePeeks.firstOrNull()?.recording?.id
@@ -396,6 +386,7 @@ internal fun PeekStrip(
                 peek = peek,
                 onClick = { onOpenRecording(peek.recording) },
                 onRetry = { peek.retryEntry?.let { onRetryRecording(peek.recording, it) } },
+                relativeTimeNow = relativeTimeNow,
                 modifier = Modifier.animateItem(
                     fadeInSpec = spring(stiffness = Spring.StiffnessMediumLow),
                     placementSpec = spring(
@@ -414,6 +405,7 @@ internal fun PeekCard(
     peek: IndexFeedViewModel.UiState.RecordingPeek,
     onClick: () -> Unit,
     onRetry: () -> Unit,
+    relativeTimeNow: Instant,
     modifier: Modifier = Modifier,
 ) {
     val colors = IndexTheme.colors
@@ -436,7 +428,7 @@ internal fun PeekCard(
             }
             Spacer(Modifier.width(6.dp))
             Text(
-                relativeTime(peek.recording.localTimestamp).uppercase(),
+                relativeTime(peek.recording.localTimestamp, relativeTimeNow).uppercase(),
                 color = colors.primary,
                 fontSize = 11.sp,
                 lineHeight = 13.sp,
@@ -537,6 +529,7 @@ internal fun TaskRow(
     task: CachedItem,
     onToggle: () -> Unit,
     onClick: () -> Unit,
+    relativeTimeNow: Instant,
 ) {
     val colors = IndexTheme.colors
     Column {
@@ -586,7 +579,7 @@ internal fun TaskRow(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
-                taskSubline(task)?.let { sub ->
+                taskSubline(task, relativeTimeNow)?.let { sub ->
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                             modifier = Modifier.padding(top = 0.dp),
@@ -611,6 +604,7 @@ internal fun LazyListScope.todosCarousel(
     todos: List<CachedItem>,
     onToggle: (CachedItem) -> Unit,
     onOpen: (CachedItem) -> Unit,
+    relativeTimeNow: Instant,
 ) {
     val pages = todos.chunked(IndexFeedViewModel.TODO_PAGE_SIZE)
     if (pages.isEmpty()) return
@@ -645,6 +639,7 @@ internal fun LazyListScope.todosCarousel(
                             task = task,
                             onToggle = { onToggle(task) },
                             onClick = { onOpen(task) },
+                            relativeTimeNow = relativeTimeNow,
                         )
                     }
                     // Intentionally NO empty-row spacers. Pager pages can
@@ -657,14 +652,14 @@ internal fun LazyListScope.todosCarousel(
     }
 }
 
-internal fun taskSubline(task: CachedItem): String? {
+internal fun taskSubline(task: CachedItem, now: Instant): String? {
     val due = task.dueAt
     return when (task.kind) {
-        "reminder" -> due?.let { formatDue(it) }
+        "reminder" -> due?.let { formatDue(it, now) }
         "scheduled" -> {
             // We could parse fields for fireKind = alarm/timer; for the home
             // preview just show due-time / "Timer".
-            due?.let { formatDue(it) } ?: "Scheduled"
+            due?.let { formatDue(it, now) } ?: "Scheduled"
         }
         else -> null
     }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/home/IndexFeedScreen.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/home/IndexFeedScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -74,6 +75,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import coredevices.indexai.data.entity.LocalRecording
 import coredevices.ring.data.entity.room.indexfeed.CachedItem
 import coredevices.ring.data.entity.room.indexfeed.CachedList
@@ -84,6 +88,7 @@ import coredevices.ring.ui.theme.IndexTheme
 import coredevices.ring.ui.theme.IndexThemeHost
 import coredevices.ring.ui.viewmodel.IndexFeedViewModel
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.delay
@@ -113,6 +118,27 @@ fun IndexFeedScreen(
 
         val colors = IndexTheme.colors
         val listState = remember { androidx.compose.foundation.lazy.LazyListState() }
+        var relativeTimeNow by remember { mutableStateOf(Clock.System.now()) }
+        val lifecycleOwner = LocalLifecycleOwner.current
+
+        // Relative labels are derived from wall-clock time, which is not Compose state.
+        // Refresh immediately when the app returns to the foreground, then once a minute
+        // while this screen remains composed.
+        DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    relativeTimeNow = Clock.System.now()
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
+            onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+        }
+        LaunchedEffect(Unit) {
+            while (true) {
+                delay(1.minutes)
+                relativeTimeNow = Clock.System.now()
+            }
+        }
 
         // Re-tap of the bottom-nav Index tab fires `scrollToTop` — bring
         // the home back to the top + close any open search. Initial scroll
@@ -143,6 +169,7 @@ fun IndexFeedScreen(
                 onStartSearch = { searching = true },
                 onCancelSearch = { searching = false; vm.clearQuery() },
                 trailingActions = headerActions,
+                relativeTimeNow = relativeTimeNow,
             )
 
             LazyColumn(
@@ -194,6 +221,7 @@ fun IndexFeedScreen(
                             peeks = state.recordings.take(8),
                             onOpenRecording = { coreNav.navigateTo(RingRoutes.RecordingDetails(it.id)) },
                             onRetryRecording = { rec, entry -> vm.retryRecording(rec.id, entry) },
+                            relativeTimeNow = relativeTimeNow,
                         )
                     }
                 }
@@ -221,6 +249,7 @@ fun IndexFeedScreen(
                         todos = state.todosPreview,
                         onToggle = { task -> vm.toggleDoneById(task.firestoreId) },
                         onOpen = { task -> coreNav.navigateTo(RingRoutes.ObjectDetails(task.firestoreId)) },
+                        relativeTimeNow = relativeTimeNow,
                     )
                 }
 
@@ -284,8 +313,8 @@ fun IndexFeedScreen(
     }
 }
 
-internal fun formatDue(at: Instant): String {
-    val diffMs = at.toEpochMilliseconds() - Clock.System.now().toEpochMilliseconds()
+internal fun formatDue(at: Instant, now: Instant = Clock.System.now()): String {
+    val diffMs = at.toEpochMilliseconds() - now.toEpochMilliseconds()
     if (diffMs < 0) return "Overdue"
     val m = (diffMs / 60_000L)
     if (m < 60) return "in ${m}m"

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/util.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/util.kt
@@ -178,9 +178,8 @@ object UITimeUtil {
 
 /** "just now" / "5m ago" / "3h ago" / "2d ago" — short relative time
  *  used by the index feed list rows. Single source of truth. */
-internal fun relativeTime(at: Instant): String {
-    val now = Clock.System.now().toEpochMilliseconds()
-    val s = ((now - at.toEpochMilliseconds()) / 1000L).toInt()
+internal fun relativeTime(at: Instant, now: Instant = Clock.System.now()): String {
+    val s = ((now.toEpochMilliseconds() - at.toEpochMilliseconds()) / 1000L).toInt()
     if (s < 60) return "just now"
     val m = s / 60
     if (m < 60) return "${m}m ago"


### PR DESCRIPTION
## Summary
- Refresh Index timestamps immediately when the app returns to the foreground.
- Update relative labels every minute while the screen is composed.
- Share the current time across recording, sync, and reminder formatters to ensure consistent recomposition.