### PR TITLE
Save watch logs to the phone once a day

### DIFF
--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/BugReportScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/BugReportScreen.kt
@@ -280,7 +280,7 @@ fun BugReportScreen(
 
                         BugReportState.UploadingAttachments -> Unit
                         is BugReportState.ReadyToShare -> {
-                            platformShareLauncher.share(it.name, it.file)
+                            platformShareLauncher.share(it.name, it.file, "application/zip")
                             setSending(false)
                             setStatus("")
                             setSendingProgress(null)

--- a/pebble/src/androidMain/kotlin/coredevices/pebble/WatchLogsDir.android.kt
+++ b/pebble/src/androidMain/kotlin/coredevices/pebble/WatchLogsDir.android.kt
@@ -1,0 +1,75 @@
+package coredevices.pebble
+
+import android.content.ContentValues
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import io.rebble.libpebblecommon.connection.AppContext
+import kotlinx.io.files.Path
+import java.io.File
+
+private val usesMediaStore = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+private fun legacyDirectory(appContext: AppContext): File {
+    val base = appContext.context.getExternalFilesDir(null) ?: appContext.context.filesDir
+    return File(base, WATCH_LOGS_FOLDER_NAME)
+}
+
+actual fun saveWatchLogCopy(appContext: AppContext, source: Path, fileName: String): String? {
+    val sourceFile = File(source.toString())
+    if (!usesMediaStore) {
+        val directory = legacyDirectory(appContext).apply { mkdirs() }
+        val target = File(directory, fileName)
+        sourceFile.inputStream().use { input -> target.outputStream().use(input::copyTo) }
+        return target.absolutePath
+    }
+    val relativePath = "${Environment.DIRECTORY_DOWNLOADS}/$WATCH_LOGS_FOLDER_NAME"
+    val values = ContentValues().apply {
+        put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+        put(MediaStore.Downloads.MIME_TYPE, "text/plain")
+        put(MediaStore.Downloads.RELATIVE_PATH, relativePath)
+    }
+    val resolver = appContext.context.contentResolver
+    val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values) ?: return null
+    val written = resolver.openOutputStream(uri)?.use { output ->
+        sourceFile.inputStream().use { input -> input.copyTo(output) }
+    }
+    if (written == null) {
+        resolver.delete(uri, null, null)
+        return null
+    }
+    return "$relativePath/$fileName"
+}
+
+actual fun pruneWatchLogCopies(appContext: AppContext, keep: Int) {
+    if (!usesMediaStore) {
+        legacyDirectory(appContext).listFiles()
+            .orEmpty()
+            .filter { it.name.startsWith(WATCH_LOGS_FILE_PREFIX) }
+            .sortedBy { it.name }
+            .dropLast(keep)
+            .forEach { it.delete() }
+        return
+    }
+    val resolver = appContext.context.contentResolver
+    val ids = mutableListOf<Long>()
+    resolver.query(
+        MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+        arrayOf(MediaStore.Downloads._ID),
+        "${MediaStore.Downloads.DISPLAY_NAME} LIKE ?",
+        arrayOf("$WATCH_LOGS_FILE_PREFIX%"),
+        "${MediaStore.Downloads.DISPLAY_NAME} ASC",
+    )?.use { cursor ->
+        val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Downloads._ID)
+        while (cursor.moveToNext()) {
+            ids += cursor.getLong(idColumn)
+        }
+    }
+    ids.dropLast(keep).forEach { id ->
+        resolver.delete(
+            MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+            "${MediaStore.Downloads._ID} = ?",
+            arrayOf(id.toString()),
+        )
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleAppDelegate.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleAppDelegate.kt
@@ -14,11 +14,14 @@ import coredevices.pebble.services.AppstoreSourceInitializer
 import coredevices.pebble.services.AnalyticsHeartbeatQueue
 import coredevices.pebble.services.MemfaultChunkQueue
 import coredevices.pebble.services.PebbleWebServices
+import coredevices.pebble.ui.autoSaveWatchLogs
+import coredevices.pebble.ui.showDebugOptions
 import coredevices.util.AppResumed
 import coredevices.util.DoneInitialOnboarding
 import coredevices.util.PermissionRequester
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.crashlytics.crashlytics
+import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.BleDiscoveredPebbleDevice
 import io.rebble.libpebblecommon.connection.CommonConnectedDevice
 import io.rebble.libpebblecommon.connection.ConnectedPebble
@@ -40,8 +43,11 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 class PebbleAppDelegate(
     private val libPebble: LibPebble,
@@ -60,6 +66,7 @@ class PebbleAppDelegate(
     private val analyticsHeartbeatQueue: AnalyticsHeartbeatQueue,
     private val pebbleWebServices: PebbleWebServices,
     private val batteryChargedNotifier: BatteryChargedNotifier,
+    private val appContext: AppContext,
 ) {
     private val logger = Logger.withTag("PebbleAppDelegate")
 
@@ -253,8 +260,40 @@ class PebbleAppDelegate(
             scope.launch {
                 analyticsHeartbeatQueue.uploadPendingFromDb()
             },
+            scope.launch {
+                autoSaveWatchLogs()
+            },
         )
         jobs.joinAll()
+    }
+
+    private suspend fun autoSaveWatchLogs() {
+        if (!settings.showDebugOptions() || !settings.autoSaveWatchLogs()) return
+        val now = clock.now()
+        val lastSaveMs = settings.getLong(LAST_WATCH_LOG_AUTO_SAVE_KEY, 0L)
+        if (now.toEpochMilliseconds() - lastSaveMs < AUTO_SAVE_WATCH_LOGS_INTERVAL.inWholeMilliseconds) {
+            return
+        }
+        val gathered = getWatchLogs()
+        if (gathered == null) {
+            logger.d { "autoSaveWatchLogs: no connected watch with log support, will retry next sync" }
+            return
+        }
+        val saved = saveWatchLogCopy(appContext, gathered, "$WATCH_LOGS_FILE_PREFIX$now.txt")
+        SystemFileSystem.delete(gathered, mustExist = false)
+        if (saved == null) {
+            logger.w { "autoSaveWatchLogs: could not save a copy, will retry next sync" }
+            return
+        }
+        pruneWatchLogCopies(appContext, MAX_AUTO_SAVED_WATCH_LOGS)
+        settings.putLong(LAST_WATCH_LOG_AUTO_SAVE_KEY, now.toEpochMilliseconds())
+        logger.d { "autoSaveWatchLogs: saved $saved" }
+    }
+
+    companion object {
+        private const val LAST_WATCH_LOG_AUTO_SAVE_KEY = "lastWatchLogAutoSaveMs"
+        private val AUTO_SAVE_WATCH_LOGS_INTERVAL = 22.hours
+        private const val MAX_AUTO_SAVED_WATCH_LOGS = 21
     }
 }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleAppDelegate.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/PebbleAppDelegate.kt
@@ -14,6 +14,8 @@ import coredevices.pebble.services.AppstoreSourceInitializer
 import coredevices.pebble.services.AnalyticsHeartbeatQueue
 import coredevices.pebble.services.MemfaultChunkQueue
 import coredevices.pebble.services.PebbleWebServices
+import coredevices.pebble.ui.autoSaveWatchLogs
+import coredevices.pebble.ui.showDebugOptions
 import coredevices.pebble.weather.WeatherFetcher
 import coredevices.pebble.weather.WeatherPlugin
 import coredevices.util.AppResumed
@@ -21,6 +23,7 @@ import coredevices.util.DoneInitialOnboarding
 import coredevices.util.PermissionRequester
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.crashlytics.crashlytics
+import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.BleDiscoveredPebbleDevice
 import io.rebble.libpebblecommon.connection.CommonConnectedDevice
 import io.rebble.libpebblecommon.connection.ConnectedPebble
@@ -43,8 +46,11 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 class PebbleAppDelegate(
     private val libPebble: LibPebble,
@@ -66,6 +72,7 @@ class PebbleAppDelegate(
     private val weatherFetcher: WeatherFetcher,
     private val plugins: Plugins,
     private val weatherPlugin: WeatherPlugin,
+    private val appContext: AppContext,
 ) {
     private val logger = Logger.withTag("PebbleAppDelegate")
 
@@ -261,8 +268,40 @@ class PebbleAppDelegate(
             scope.launch {
                 analyticsHeartbeatQueue.uploadPendingFromDb()
             },
+            scope.launch {
+                autoSaveWatchLogs()
+            },
         )
         jobs.joinAll()
+    }
+
+    private suspend fun autoSaveWatchLogs() {
+        if (!settings.showDebugOptions() || !settings.autoSaveWatchLogs()) return
+        val now = clock.now()
+        val lastSaveMs = settings.getLong(LAST_WATCH_LOG_AUTO_SAVE_KEY, 0L)
+        if (now.toEpochMilliseconds() - lastSaveMs < AUTO_SAVE_WATCH_LOGS_INTERVAL.inWholeMilliseconds) {
+            return
+        }
+        val gathered = getWatchLogs()
+        if (gathered == null) {
+            logger.d { "autoSaveWatchLogs: no connected watch with log support, will retry next sync" }
+            return
+        }
+        val saved = saveWatchLogCopy(appContext, gathered, "$WATCH_LOGS_FILE_PREFIX$now.txt")
+        SystemFileSystem.delete(gathered, mustExist = false)
+        if (saved == null) {
+            logger.w { "autoSaveWatchLogs: could not save a copy, will retry next sync" }
+            return
+        }
+        pruneWatchLogCopies(appContext, MAX_AUTO_SAVED_WATCH_LOGS)
+        settings.putLong(LAST_WATCH_LOG_AUTO_SAVE_KEY, now.toEpochMilliseconds())
+        logger.d { "autoSaveWatchLogs: saved $saved" }
+    }
+
+    companion object {
+        private const val LAST_WATCH_LOG_AUTO_SAVE_KEY = "lastWatchLogAutoSaveMs"
+        private val AUTO_SAVE_WATCH_LOGS_INTERVAL = 22.hours
+        private const val MAX_AUTO_SAVED_WATCH_LOGS = 21
     }
 }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/WatchLogsDir.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/WatchLogsDir.kt
@@ -1,0 +1,16 @@
+package coredevices.pebble
+
+import io.rebble.libpebblecommon.connection.AppContext
+import kotlinx.io.files.Path
+
+internal const val WATCH_LOGS_FOLDER_NAME = "Pebble watch logs"
+internal const val WATCH_LOGS_FILE_PREFIX = "watch-logs-"
+
+/**
+ * Copies [source] into shared storage the user can browse, returning a description of where it
+ * landed, or null if it could not be saved.
+ */
+expect fun saveWatchLogCopy(appContext: AppContext, source: Path, fileName: String): String?
+
+/** Deletes all but the [keep] newest saved copies. */
+expect fun pruneWatchLogCopies(appContext: AppContext, keep: Int)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -352,6 +352,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
     val showFakeHealthDataDialog = remember { mutableStateOf(false) }
     var showSignInDialog by remember { mutableStateOf(false) }
     var debugOptionsEnabled by remember { mutableStateOf(settings.showDebugOptions()) }
+    var autoSaveWatchLogsEnabled by remember { mutableStateOf(settings.autoSaveWatchLogs()) }
     var pendingSTTModeDialog by remember { mutableStateOf<CactusSTTMode?>(null) }
     var showSpokenLanguageDialog by remember { mutableStateOf(false) }
     val recommendedSTTModel = modelManager.getRecommendedSTTModel()
@@ -1399,6 +1400,18 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                         settings.set(SHOW_DEBUG_OPTIONS_SETTINGS_KEY, it)
                         debugOptionsEnabled = it
                     },
+                ),
+                basicSettingsToggleItem(
+                    title = "Auto-save watch logs",
+                    description = "Once a day, save the connected watch's logs to this phone's Downloads folder. For firmware debugging.",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Debug,
+                    checked = autoSaveWatchLogsEnabled,
+                    onCheckChanged = {
+                        settings.setAutoSaveWatchLogs(it)
+                        autoSaveWatchLogsEnabled = it
+                    },
+                    isDebugSetting = true,
                 ),
                 basicSettingsToggleItem(
                     title = "PKJS Debugger",
@@ -2678,8 +2691,14 @@ fun <T> basicSettingsDropdownItem(
 )
 
 private const val SHOW_DEBUG_OPTIONS_SETTINGS_KEY = "showDebugOptions"
+private const val AUTO_SAVE_WATCH_LOGS_SETTINGS_KEY = "autoSaveWatchLogs"
 
 fun Settings.showDebugOptions() = getBoolean(SHOW_DEBUG_OPTIONS_SETTINGS_KEY, false)
+
+fun Settings.autoSaveWatchLogs() = getBoolean(AUTO_SAVE_WATCH_LOGS_SETTINGS_KEY, false)
+
+fun Settings.setAutoSaveWatchLogs(enabled: Boolean) =
+    putBoolean(AUTO_SAVE_WATCH_LOGS_SETTINGS_KEY, enabled)
 
 @Composable
 fun PKJSCopyTokenDialog(onDismissRequest: () -> Unit) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -353,6 +353,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
     val showFakeHealthDataDialog = remember { mutableStateOf(false) }
     var showSignInDialog by remember { mutableStateOf(false) }
     var debugOptionsEnabled by remember { mutableStateOf(settings.showDebugOptions()) }
+    var autoSaveWatchLogsEnabled by remember { mutableStateOf(settings.autoSaveWatchLogs()) }
     var pendingSTTModeDialog by remember { mutableStateOf<CactusSTTMode?>(null) }
     var showSpokenLanguageDialog by remember { mutableStateOf(false) }
     val recommendedSTTModel = modelManager.getRecommendedSTTModel()
@@ -1400,6 +1401,18 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                         settings.set(SHOW_DEBUG_OPTIONS_SETTINGS_KEY, it)
                         debugOptionsEnabled = it
                     },
+                ),
+                basicSettingsToggleItem(
+                    title = "Auto-save watch logs",
+                    description = "Once a day, save the connected watch's logs to this phone's Downloads folder. For firmware debugging.",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Debug,
+                    checked = autoSaveWatchLogsEnabled,
+                    onCheckChanged = {
+                        settings.setAutoSaveWatchLogs(it)
+                        autoSaveWatchLogsEnabled = it
+                    },
+                    isDebugSetting = true,
                 ),
                 basicSettingsToggleItem(
                     title = "PKJS Debugger",
@@ -2732,8 +2745,14 @@ fun <T> basicSettingsDropdownItem(
 )
 
 private const val SHOW_DEBUG_OPTIONS_SETTINGS_KEY = "showDebugOptions"
+private const val AUTO_SAVE_WATCH_LOGS_SETTINGS_KEY = "autoSaveWatchLogs"
 
 fun Settings.showDebugOptions() = getBoolean(SHOW_DEBUG_OPTIONS_SETTINGS_KEY, false)
+
+fun Settings.autoSaveWatchLogs() = getBoolean(AUTO_SAVE_WATCH_LOGS_SETTINGS_KEY, false)
+
+fun Settings.setAutoSaveWatchLogs(enabled: Boolean) =
+    putBoolean(AUTO_SAVE_WATCH_LOGS_SETTINGS_KEY, enabled)
 
 @Composable
 fun PKJSCopyTokenDialog(onDismissRequest: () -> Unit) {

--- a/pebble/src/iosMain/kotlin/coredevices/pebble/WatchLogsDir.ios.kt
+++ b/pebble/src/iosMain/kotlin/coredevices/pebble/WatchLogsDir.ios.kt
@@ -1,0 +1,36 @@
+package coredevices.pebble
+
+import io.rebble.libpebblecommon.connection.AppContext
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+private fun documentsDirectory(): Path {
+    val documents = NSSearchPathForDirectoriesInDomains(
+        NSDocumentDirectory, NSUserDomainMask, true
+    ).first() as String
+    return Path(documents, WATCH_LOGS_FOLDER_NAME)
+}
+
+actual fun saveWatchLogCopy(appContext: AppContext, source: Path, fileName: String): String? {
+    val directory = documentsDirectory()
+    SystemFileSystem.createDirectories(directory)
+    val target = Path(directory, fileName)
+    SystemFileSystem.source(source).buffered().use { input ->
+        SystemFileSystem.sink(target).buffered().use { output -> output.transferFrom(input) }
+    }
+    return "$WATCH_LOGS_FOLDER_NAME/$fileName"
+}
+
+actual fun pruneWatchLogCopies(appContext: AppContext, keep: Int) {
+    val directory = documentsDirectory()
+    if (SystemFileSystem.metadataOrNull(directory) == null) return
+    SystemFileSystem.list(directory)
+        .filter { it.name.startsWith(WATCH_LOGS_FILE_PREFIX) }
+        .sortedBy { it.name }
+        .dropLast(keep)
+        .forEach { SystemFileSystem.delete(it, mustExist = false) }
+}

--- a/util/src/androidMain/kotlin/PlatformShareLauncher.android.kt
+++ b/util/src/androidMain/kotlin/PlatformShareLauncher.android.kt
@@ -7,13 +7,13 @@ import kotlinx.io.files.Path
 import java.io.File
 
 actual class PlatformShareLauncher(private val context: Context) {
-    actual fun share(text: String?, file: Path) {
+    actual fun share(text: String?, file: Path, mimeType: String) {
         val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", File(file.toString()))
         val intent = Intent().apply {
             action = Intent.ACTION_SEND
             if (text != null) putExtra(Intent.EXTRA_TEXT, text)
             putExtra(Intent.EXTRA_STREAM, uri)
-            type = "audio/wav"
+            type = mimeType
         }
         context.startActivity(
             Intent.createChooser(intent, null)

--- a/util/src/commonMain/kotlin/PlatformShareLauncher.kt
+++ b/util/src/commonMain/kotlin/PlatformShareLauncher.kt
@@ -2,6 +2,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 import kotlinx.io.files.Path
 
 expect class PlatformShareLauncher {
-    fun share(text: String?, file: Path)
+    fun share(text: String?, file: Path, mimeType: String)
     fun shareImage(image: ImageBitmap, filename: String)
 }

--- a/util/src/iosMain/kotlin/PlatformShareLauncher.ios.kt
+++ b/util/src/iosMain/kotlin/PlatformShareLauncher.ios.kt
@@ -17,7 +17,7 @@ import org.jetbrains.skia.Image
 import org.jetbrains.skia.EncodedImageFormat
 
 actual class PlatformShareLauncher() {
-    actual fun share(text: String?, file: Path) {
+    actual fun share(text: String?, file: Path, mimeType: String) {
         val viewController = UIApplication.sharedApplication.keyWindow?.rootViewController!!
         val activityViewController = UIActivityViewController(listOf(file.toNSURL()), null)
         viewController.presentViewController(activityViewController, true, null)


### PR DESCRIPTION
The watch only keeps a couple of days of logs, and getting them off currently needs a person: submitting a bug report, or sharing the report zip from the Bug Report screen. The pipelines that run on their own carry crash dumps and numeric metrics, not logs. So a firmware contributor collecting log data over a longer stretch, without access to the server side, has to remember to pull logs every couple of days or silently lose the oldest ones.

This adds an Auto-save watch logs toggle to the debug settings. When it is on, the daily background sync also gathers the connected watch's logs and keeps the newest 21 copies in the phone's Downloads folder under `Pebble watch logs`. If no watch is reachable it tries again on the next sync instead of skipping the day. Android 10 and newer write through `MediaStore`. Older Android versions and iOS fall back to app storage.

Off by default and hidden unless debug options are on, so nothing changes for regular users.

The other commit fixes the share sheet labeling the bug report zip as an audio file. `share()` was hardcoded to `audio/wav` from when recordings were its only payload, and now takes the type from the caller.

Written with AI assistance (Claude), and exercised on a Pixel 6 with a Pebble Time 2.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.
