### PR TITLE
Let the user choose which phone calendar Index adds events to

### DIFF
--- a/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
+++ b/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
@@ -702,6 +702,7 @@ private class E2EPreferences : Preferences {
     override val autoDismissActionNotifications: StateFlow<Boolean> = MutableStateFlow(true)
     override val backupEnabled: StateFlow<Boolean> = MutableStateFlow(false)
     override val phoneCalendarEnabled: StateFlow<Boolean> = MutableStateFlow(false)
+    override val phoneCalendarId: StateFlow<String?> = MutableStateFlow(null)
     override val useEncryption: StateFlow<Boolean> = MutableStateFlow(false)
     override val encryptionKeyFingerprint: StateFlow<String?> = MutableStateFlow(null)
     override val lastWipedRing: StateFlow<String?> = MutableStateFlow(null)
@@ -725,6 +726,7 @@ private class E2EPreferences : Preferences {
     override fun setAutoDismissActionNotifications(enabled: Boolean) {}
     override fun setBackupEnabled(enabled: Boolean) {}
     override fun setPhoneCalendarEnabled(enabled: Boolean) {}
+    override fun setPhoneCalendarId(platformId: String?) {}
     override fun setUseEncryption(enabled: Boolean) {}
     override fun setEncryptionKeyFingerprint(fingerprint: String?) {}
     override fun setLastWipedRing(id: String?) {}

--- a/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
+++ b/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
@@ -102,6 +102,7 @@ class FakePreferences : Preferences {
     override val autoDismissActionNotifications: StateFlow<Boolean> = MutableStateFlow(true)
     override val backupEnabled: StateFlow<Boolean> = MutableStateFlow(false)
     override val phoneCalendarEnabled: StateFlow<Boolean> = MutableStateFlow(false)
+    override val phoneCalendarId: StateFlow<String?> = MutableStateFlow(null)
     override val useEncryption: StateFlow<Boolean> = MutableStateFlow(false)
     override val encryptionKeyFingerprint: StateFlow<String?> = MutableStateFlow(null)
     override val lastWipedRing: StateFlow<String?> = MutableStateFlow(null)
@@ -125,6 +126,7 @@ class FakePreferences : Preferences {
     override fun setAutoDismissActionNotifications(enabled: Boolean) {}
     override fun setBackupEnabled(enabled: Boolean) {}
     override fun setPhoneCalendarEnabled(enabled: Boolean) {}
+    override fun setPhoneCalendarId(platformId: String?) {}
     override fun setUseEncryption(enabled: Boolean) {}
     override fun setEncryptionKeyFingerprint(fingerprint: String?) {}
     override fun setLastWipedRing(id: String?) {}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/calendar/CreateCalendarEventTool.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/calendar/CreateCalendarEventTool.kt
@@ -257,6 +257,7 @@ class CreateCalendarEventTool : BuiltInMcpTool(
                     endTime = safeEnd,
                     location = args.location,
                     description = args.description,
+                    calendarId = preferences.phoneCalendarId.value,
                 )
             ) ?: return ToolCallResult(
                 JsonSnake.encodeToString(CreateEventResult(success = false, errorMessage = "Could not create the event. The calendar may not be accessible.")),

--- a/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/database/Preferences.kt
@@ -36,6 +36,8 @@ interface Preferences: BasePreferences {
     /** Whether the user has connected the Phone Calendar integration (Accounts → Add integration).
      *  The calendar tool stays unavailable until this is enabled AND calendar permission is granted. */
     val phoneCalendarEnabled: StateFlow<Boolean>
+    /** Platform id of the calendar the agent adds events to; null means the phone's default. */
+    val phoneCalendarId: StateFlow<String?>
     val useEncryption: StateFlow<Boolean>
     val encryptionKeyFingerprint: StateFlow<String?>
     val lastWipedRing: StateFlow<String?>
@@ -60,6 +62,7 @@ interface Preferences: BasePreferences {
     fun setAutoDismissActionNotifications(enabled: Boolean)
     fun setBackupEnabled(enabled: Boolean)
     fun setPhoneCalendarEnabled(enabled: Boolean)
+    fun setPhoneCalendarId(platformId: String?)
     fun setUseEncryption(enabled: Boolean)
     fun setEncryptionKeyFingerprint(fingerprint: String?)
     fun setLastWipedRing(id: String?)
@@ -160,6 +163,8 @@ class PreferencesImpl(private val settings: Settings): Preferences {
     override val backupEnabled = _backupEnabled.asStateFlow()
     private val _phoneCalendarEnabled = MutableStateFlow(settings.getBoolean("phone_calendar_enabled", false))
     override val phoneCalendarEnabled = _phoneCalendarEnabled.asStateFlow()
+    private val _phoneCalendarId = MutableStateFlow(settings.getStringOrNull("phone_calendar_id"))
+    override val phoneCalendarId = _phoneCalendarId.asStateFlow()
     private val _useEncryption = MutableStateFlow(settings.getBoolean("use_encryption", false))
     override val useEncryption = _useEncryption.asStateFlow()
     private val _encryptionKeyFingerprint = MutableStateFlow(settings.getStringOrNull("encryption_key_fingerprint"))
@@ -281,6 +286,15 @@ class PreferencesImpl(private val settings: Settings): Preferences {
     override fun setPhoneCalendarEnabled(enabled: Boolean) {
         settings.putBoolean("phone_calendar_enabled", enabled)
         _phoneCalendarEnabled.value = enabled
+    }
+
+    override fun setPhoneCalendarId(platformId: String?) {
+        if (platformId != null) {
+            settings.putString("phone_calendar_id", platformId)
+        } else {
+            settings.remove("phone_calendar_id")
+        }
+        _phoneCalendarId.value = platformId
     }
 
     override fun setUseEncryption(enabled: Boolean) {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
@@ -298,8 +298,10 @@ fun PhoneCalendarPicker() {
             }
             loaded.isEmpty() -> Text("No calendars found that Index can add events to.")
             else -> {
-                // Nothing picked yet: the first calendar is the one the phone would use anyway.
-                val effectiveId = selectedId ?: loaded.first().platformId
+                // Same fallback as event creation: without a choice - or when the chosen
+                // calendar is gone - the first one is what the phone would use anyway.
+                val effectiveId = loaded.firstOrNull { it.platformId == selectedId }?.platformId
+                    ?: loaded.first().platformId
                 loaded.forEach { calendar ->
                     Row(
                         modifier = Modifier

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,6 +61,8 @@ import coredevices.util.PermissionResult
 import coredevices.util.Platform
 import coredevices.util.isAndroid
 import coredevices.util.rememberUiContext
+import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.database.entity.CalendarEntity
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -202,6 +205,8 @@ fun PhoneCalendarDialog(
 
     M3Dialog(
         onDismissRequest = onDismiss,
+        // The calendar list shown once connected can be long.
+        scrollableContent = true,
         title = { Text(PHONE_CALENDAR_TITLE) },
         buttons = {
             TextButton(onClick = onDismiss) {
@@ -256,10 +261,70 @@ fun PhoneCalendarDialog(
                 }
             }
             is SignInState.Success -> {
-                Text("Phone Calendar connected.")
+                Column {
+                    Text("Phone Calendar connected.")
+                    Spacer(Modifier.height(16.dp))
+                    PhoneCalendarPicker()
+                }
             }
             is SignInState.Error -> {
                 Text(s.message, color = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}
+
+/** Picks which of the phone's calendars Index adds events to. */
+@Composable
+fun PhoneCalendarPicker() {
+    val preferences = koinInject<Preferences>()
+    val libPebble = koinInject<LibPebble>()
+    val selectedId by preferences.phoneCalendarId.collectAsState()
+    var calendars by remember { mutableStateOf<List<CalendarEntity>?>(null) }
+    LaunchedEffect(Unit) {
+        calendars = libPebble.writableCalendars()
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text("Add events to", style = MaterialTheme.typography.titleSmall)
+        Spacer(Modifier.height(4.dp))
+        val loaded = calendars
+        when {
+            loaded == null -> Box(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+            loaded.isEmpty() -> Text("No calendars found that Index can add events to.")
+            else -> {
+                // Nothing picked yet: the first calendar is the one the phone would use anyway.
+                val effectiveId = selectedId ?: loaded.first().platformId
+                loaded.forEach { calendar ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { preferences.setPhoneCalendarId(calendar.platformId) }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = calendar.platformId == effectiveId,
+                            onClick = { preferences.setPhoneCalendarId(calendar.platformId) },
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Column {
+                            Text(calendar.name, style = MaterialTheme.typography.bodyLarge)
+                            if (calendar.ownerName != calendar.name) {
+                                Text(
+                                    calendar.ownerName,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -1534,6 +1534,8 @@ fun AuthorizedIntegrations(preferences: Preferences) {
 private fun PhoneCalendarConfigDialog(preferences: Preferences, onDismiss: () -> Unit) {
     M3Dialog(
         onDismissRequest = onDismiss,
+        // The calendar list can be long; scroll it so the buttons stay reachable.
+        scrollableContent = true,
         title = { Text(PHONE_CALENDAR_TITLE) },
         buttons = {
             TextButton(
@@ -1545,7 +1547,11 @@ private fun PhoneCalendarConfigDialog(preferences: Preferences, onDismiss: () ->
             TextButton(onClick = onDismiss) { Text("Close") }
         }
     ) {
-        Text("Index can add events to your phone's calendar when you explicitly ask for a calendar event.")
+        Column {
+            Text("Index can add events to your phone's calendar when you explicitly ask for a calendar event.")
+            Spacer(Modifier.height(16.dp))
+            PhoneCalendarPicker()
+        }
     }
 }
 

--- a/experimental/src/iosMain/kotlin/coredevices/TestUtil.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/TestUtil.kt
@@ -151,6 +151,8 @@ private object PreferencesTestImpl: Preferences {
         get() = MutableStateFlow(true)
     override val phoneCalendarEnabled: StateFlow<Boolean>
         get() = MutableStateFlow(false)
+    override val phoneCalendarId: StateFlow<String?>
+        get() = MutableStateFlow(null)
     override val useEncryption: StateFlow<Boolean>
         get() = MutableStateFlow(false)
     override val encryptionKeyFingerprint: StateFlow<String?>
@@ -221,6 +223,7 @@ private object PreferencesTestImpl: Preferences {
 
     override fun setBackupEnabled(enabled: Boolean) {}
     override fun setPhoneCalendarEnabled(enabled: Boolean) {}
+    override fun setPhoneCalendarId(platformId: String?) {}
     override fun setUseEncryption(enabled: Boolean) {}
     override fun setEncryptionKeyFingerprint(fingerprint: String?) {}
     override fun setLastWipedRing(id: String?) {}

--- a/libpebble3/src/androidHostTest/kotlin/io/rebble/libpebblecommon/calendar/OwnAccountFirstTest.kt
+++ b/libpebble3/src/androidHostTest/kotlin/io/rebble/libpebblecommon/calendar/OwnAccountFirstTest.kt
@@ -1,0 +1,44 @@
+package io.rebble.libpebblecommon.calendar
+
+import io.rebble.libpebblecommon.database.entity.CalendarEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private fun calendar(
+    platformId: String,
+    accountName: String = "me@example.com",
+    ownerAccount: String = "shared@example.com",
+) = CalendarEntity(
+    platformId = platformId,
+    name = "Calendar $platformId",
+    ownerName = accountName,
+    ownerId = ownerAccount,
+    color = 0,
+    enabled = true,
+)
+
+class OwnAccountFirstTest {
+    @Test
+    fun ownCalendarMovesToTheFront() {
+        val calendars = listOf(
+            calendar("1"),
+            calendar("2", ownerAccount = "me@example.com"),
+            calendar("3"),
+        )
+        assertEquals(
+            listOf("2", "1", "3"),
+            calendars.ownAccountFirst().map { it.platformId },
+        )
+    }
+
+    @Test
+    fun withoutOwnCalendarOrderIsUnchanged() {
+        val calendars = listOf(calendar("1"), calendar("2"))
+        assertEquals(calendars, calendars.ownAccountFirst())
+    }
+
+    @Test
+    fun emptyList() {
+        assertEquals(emptyList(), emptyList<CalendarEntity>().ownAccountFirst())
+    }
+}

--- a/libpebble3/src/androidHostTest/kotlin/io/rebble/libpebblecommon/calendar/OwnAccountFirstTest.kt
+++ b/libpebble3/src/androidHostTest/kotlin/io/rebble/libpebblecommon/calendar/OwnAccountFirstTest.kt
@@ -48,6 +48,6 @@ class OwnAccountFirstTest {
 
     @Test
     fun emptyList() {
-        assertEquals(emptyList(), emptyList<CalendarEntity>().ownAccountFirst())
+        assertEquals(emptyList<CalendarEntity>(), emptyList<CalendarEntity>().ownAccountFirst())
     }
 }

--- a/libpebble3/src/androidHostTest/kotlin/io/rebble/libpebblecommon/calendar/OwnAccountFirstTest.kt
+++ b/libpebble3/src/androidHostTest/kotlin/io/rebble/libpebblecommon/calendar/OwnAccountFirstTest.kt
@@ -38,6 +38,15 @@ class OwnAccountFirstTest {
     }
 
     @Test
+    fun calendarWithNoAccountIsNotTreatedAsOwn() {
+        val calendars = listOf(
+            calendar("1", accountName = "unknown", ownerAccount = "unknown"),
+            calendar("2"),
+        )
+        assertEquals(calendars, calendars.ownAccountFirst())
+    }
+
+    @Test
     fun emptyList() {
         assertEquals(emptyList(), emptyList<CalendarEntity>().ownAccountFirst())
     }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/AndroidSystemCalendar.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/AndroidSystemCalendar.kt
@@ -521,8 +521,6 @@ class AndroidSystemCalendar(
     override fun supportsPinActions(): Boolean = true
 }
 
-private const val UNKNOWN_ACCOUNT = "unknown"
-
 /**
  * Lenient parse for the writable-calendar list: unlike the sync list, a calendar missing its
  * display name or colour is still a valid target for new events.
@@ -547,18 +545,4 @@ private fun Cursor.toWritableCalendar(): CalendarEntity? {
             ?.let { getInt(it) } ?: 0,
         enabled = true,
     )
-}
-
-/**
- * Puts the account's own calendar (ownerAccount == accountName) first — that's the one Android
- * treats as primary, and where events go when the user hasn't picked a calendar.
- *
- * Deliberately does NOT order by IS_PRIMARY — that is a computed column that some calendar
- * providers reject in a sort clause (the query then throws / returns null), which would make
- * event creation silently fail even when writable calendars exist.
- */
-internal fun List<CalendarEntity>.ownAccountFirst(): List<CalendarEntity> {
-    val own = firstOrNull { it.ownerName != UNKNOWN_ACCOUNT && it.ownerId == it.ownerName }
-        ?: return this
-    return listOf(own) + filterNot { it.platformId == own.platformId }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/AndroidSystemCalendar.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/AndroidSystemCalendar.kt
@@ -17,9 +17,11 @@ import io.rebble.libpebblecommon.database.entity.CalendarEntity
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
 import io.rebble.libpebblecommon.util.PrivateLogger
 import io.rebble.libpebblecommon.util.obfuscate
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.TimeZone
 import kotlin.time.Instant
 
@@ -468,13 +470,36 @@ class AndroidSystemCalendar(
                     appContext.context.checkSelfPermission(Manifest.permission.WRITE_CALENDAR) == PackageManager.PERMISSION_GRANTED
     }
 
+    // Queried straight from the settings UI, so keep the provider query off the main thread.
+    override suspend fun getWritableCalendars(): List<CalendarEntity> = withContext(Dispatchers.IO) {
+        try {
+            contentResolver.query(
+                calendarUri,
+                calendarProjection,
+                "${CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL} >= ?",
+                arrayOf(CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR.toString()),
+                null
+            )?.use { cursor ->
+                val list = mutableListOf<CalendarEntity>()
+                while (cursor.moveToNext()) {
+                    list.add(cursor.toWritableCalendar() ?: continue)
+                }
+                list.ownAccountFirst()
+            } ?: emptyList()
+        } catch (e: Exception) {
+            logger.e(e) { "Error querying writable calendars" }
+            emptyList()
+        }
+    }
+
     override suspend fun createEvent(event: NewCalendarEvent): String? {
-        val calendarId = findPrimaryWritableCalendarId() ?: run {
+        val calendar = getWritableCalendars().resolveWritableTarget(event.calendarId) ?: run {
             logger.w("No writable calendar found to create event")
             return null
         }
+        val calendarId = calendar.platformId
         val values = ContentValues().apply {
-            put(CalendarContract.Events.CALENDAR_ID, calendarId)
+            put(CalendarContract.Events.CALENDAR_ID, calendarId.toLong())
             put(CalendarContract.Events.TITLE, event.title)
             event.description?.let { put(CalendarContract.Events.DESCRIPTION, it) }
             event.location?.let { put(CalendarContract.Events.EVENT_LOCATION, it) }
@@ -493,48 +518,44 @@ class AndroidSystemCalendar(
         }
     }
 
-    /**
-     * Best calendar to create events in: the account's own primary calendar
-     * (where ownerAccount == accountName), else the first calendar we can write to.
-     *
-     * Deliberately does NOT order by IS_PRIMARY — that is a computed column that some calendar
-     * providers reject in a sort clause (the query then throws / returns null), which would make
-     * event creation silently fail even when writable calendars exist.
-     */
-    private fun findPrimaryWritableCalendarId(): Long? {
-        val projection = arrayOf(
-            CalendarContract.Calendars._ID,
-            CalendarContract.Calendars.ACCOUNT_NAME,
-            CalendarContract.Calendars.OWNER_ACCOUNT,
-            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL,
-        )
-        return try {
-            contentResolver.query(
-                calendarUri,
-                projection,
-                "${CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL} >= ?",
-                arrayOf(CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR.toString()),
-                null
-            )?.use { cursor ->
-                var firstWritable: Long? = null
-                var ownPrimary: Long? = null
-                while (cursor.moveToNext()) {
-                    val id = cursor.getNullableColumnIndex(CalendarContract.Calendars._ID)
-                        ?.let { cursor.getLong(it) } ?: continue
-                    if (firstWritable == null) firstWritable = id
-                    val account = cursor.getNullableColumnIndex(CalendarContract.Calendars.ACCOUNT_NAME)
-                        ?.let { cursor.getString(it) }
-                    val owner = cursor.getNullableColumnIndex(CalendarContract.Calendars.OWNER_ACCOUNT)
-                        ?.let { cursor.getString(it) }
-                    if (ownPrimary == null && account != null && account == owner) ownPrimary = id
-                }
-                ownPrimary ?: firstWritable
-            }
-        } catch (e: Exception) {
-            logger.e(e) { "Error querying calendars for event creation" }
-            null
-        }
-    }
-
     override fun supportsPinActions(): Boolean = true
+}
+
+/**
+ * Lenient parse for the writable-calendar list: unlike the sync list, a calendar missing its
+ * display name or colour is still a valid target for new events.
+ */
+private fun Cursor.toWritableCalendar(): CalendarEntity? {
+    val id = getNullableColumnIndex(CalendarContract.Calendars._ID)?.let { getLong(it) } ?: run {
+        logger.w("Calendar has no ID")
+        return null
+    }
+    val accountName = getNullableColumnIndex(CalendarContract.Calendars.ACCOUNT_NAME)
+        ?.let { getString(it) }
+    val displayName = getNullableColumnIndex(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME)
+        ?.let { getString(it) }
+    val ownerAccount = getNullableColumnIndex(CalendarContract.Calendars.OWNER_ACCOUNT)
+        ?.let { getString(it) }
+    return CalendarEntity(
+        platformId = id.toString(),
+        name = displayName ?: accountName ?: "Calendar",
+        ownerName = accountName ?: "unknown",
+        ownerId = ownerAccount ?: "unknown",
+        color = getNullableColumnIndex(CalendarContract.Calendars.CALENDAR_COLOR)
+            ?.let { getInt(it) } ?: 0,
+        enabled = true,
+    )
+}
+
+/**
+ * Puts the account's own calendar (ownerAccount == accountName) first — that's the one Android
+ * treats as primary, and where events go when the user hasn't picked a calendar.
+ *
+ * Deliberately does NOT order by IS_PRIMARY — that is a computed column that some calendar
+ * providers reject in a sort clause (the query then throws / returns null), which would make
+ * event creation silently fail even when writable calendars exist.
+ */
+internal fun List<CalendarEntity>.ownAccountFirst(): List<CalendarEntity> {
+    val own = firstOrNull { it.ownerId == it.ownerName } ?: return this
+    return listOf(own) + filterNot { it.platformId == own.platformId }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/AndroidSystemCalendar.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/AndroidSystemCalendar.kt
@@ -521,6 +521,8 @@ class AndroidSystemCalendar(
     override fun supportsPinActions(): Boolean = true
 }
 
+private const val UNKNOWN_ACCOUNT = "unknown"
+
 /**
  * Lenient parse for the writable-calendar list: unlike the sync list, a calendar missing its
  * display name or colour is still a valid target for new events.
@@ -539,8 +541,8 @@ private fun Cursor.toWritableCalendar(): CalendarEntity? {
     return CalendarEntity(
         platformId = id.toString(),
         name = displayName ?: accountName ?: "Calendar",
-        ownerName = accountName ?: "unknown",
-        ownerId = ownerAccount ?: "unknown",
+        ownerName = accountName ?: UNKNOWN_ACCOUNT,
+        ownerId = ownerAccount ?: UNKNOWN_ACCOUNT,
         color = getNullableColumnIndex(CalendarContract.Calendars.CALENDAR_COLOR)
             ?.let { getInt(it) } ?: 0,
         enabled = true,
@@ -556,6 +558,7 @@ private fun Cursor.toWritableCalendar(): CalendarEntity? {
  * event creation silently fail even when writable calendars exist.
  */
 internal fun List<CalendarEntity>.ownAccountFirst(): List<CalendarEntity> {
-    val own = firstOrNull { it.ownerId == it.ownerName } ?: return this
+    val own = firstOrNull { it.ownerName != UNKNOWN_ACCOUNT && it.ownerId == it.ownerName }
+        ?: return this
     return listOf(own) + filterNot { it.platformId == own.platformId }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/WritableCalendars.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/calendar/WritableCalendars.kt
@@ -1,0 +1,22 @@
+package io.rebble.libpebblecommon.calendar
+
+import io.rebble.libpebblecommon.database.entity.CalendarEntity
+
+// Kept out of AndroidSystemCalendar.kt: that file's top-level CalendarContract constants are
+// null on the host JVM, so a unit test touching its facade class dies in the class initializer.
+
+internal const val UNKNOWN_ACCOUNT = "unknown"
+
+/**
+ * Puts the account's own calendar (ownerAccount == accountName) first — that's the one Android
+ * treats as primary, and where events go when the user hasn't picked a calendar.
+ *
+ * Deliberately does NOT order by IS_PRIMARY — that is a computed column that some calendar
+ * providers reject in a sort clause (the query then throws / returns null), which would make
+ * event creation silently fail even when writable calendars exist.
+ */
+internal fun List<CalendarEntity>.ownAccountFirst(): List<CalendarEntity> {
+    val own = firstOrNull { it.ownerName != UNKNOWN_ACCOUNT && it.ownerId == it.ownerName }
+        ?: return this
+    return listOf(own) + filterNot { it.platformId == own.platformId }
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/CalendarEvent.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/CalendarEvent.kt
@@ -51,8 +51,10 @@ data class CalendarEvent(
 }
 
 /**
- * Parameters for creating a new event in the device's primary/default calendar.
+ * Parameters for creating a new event.
  * Minimal v1 field set; all-day/attendees/recurrence intentionally omitted (see RING-84).
+ *
+ * @param calendarId platform id of the calendar to add the event to; null uses the default one.
  */
 data class NewCalendarEvent(
     val title: String,
@@ -60,6 +62,7 @@ data class NewCalendarEvent(
     val endTime: Instant,
     val location: String? = null,
     val description: String? = null,
+    val calendarId: String? = null,
 )
 
 private fun CalendarEvent.generateCompositeBackingId() = "${calendarId}T${baseEventId}T${startTime}"

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/PhoneCalendarSyncer.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/PhoneCalendarSyncer.kt
@@ -244,6 +244,9 @@ class PhoneCalendarSyncer(
 
     override fun calendars(): Flow<List<CalendarEntity>> = calendarDao.getFlow()
 
+    override suspend fun writableCalendars(): List<CalendarEntity> =
+        systemCalendar.getWritableCalendars()
+
     override suspend fun createEvent(event: NewCalendarEvent): String? =
         systemCalendar.createEvent(event)
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/SystemCalendar.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/SystemCalendar.kt
@@ -12,7 +12,13 @@ interface SystemCalendar {
     fun hasPermission(): Boolean
 
     /**
-     * Create an event in the device's primary/default calendar.
+     * Calendars the user can create events in, the platform's default for new events first.
+     */
+    suspend fun getWritableCalendars(): List<CalendarEntity>
+
+    /**
+     * Create an event in [NewCalendarEvent.calendarId], or the default calendar when that is
+     * null or no longer writable.
      * @return the platform id of the created event, or null if creation failed (no permission,
      *         no writable calendar, or a platform error).
      */
@@ -25,3 +31,10 @@ interface SystemCalendar {
      */
     fun supportsPinActions(): Boolean
 }
+
+/**
+ * Which calendar an event goes in, given [getWritableCalendars] and the user's choice: their
+ * calendar if it's still writable, otherwise the platform default (first in the list).
+ */
+internal fun List<CalendarEntity>.resolveWritableTarget(requestedId: String?): CalendarEntity? =
+    firstOrNull { it.platformId == requestedId } ?: firstOrNull()

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -328,6 +328,8 @@ class FakeLibPebble : LibPebble {
         // No-op
     }
 
+    override suspend fun writableCalendars(): List<CalendarEntity> = emptyList()
+
     override suspend fun createEvent(event: NewCalendarEvent): String? = null
 
     // OtherPebbleApps interface

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
@@ -277,8 +277,8 @@ interface Calendar {
     /** Calendars the user can create events in, the phone's default for new events first. */
     suspend fun writableCalendars(): List<CalendarEntity>
 
-    /** Create an event in [NewCalendarEvent.calendarId], or the phone's default calendar when
-     *  that is null. Returns the new event id, or null. */
+    /** Create an event in [NewCalendarEvent.calendarId], falling back to the phone's default
+     *  calendar when that is null or no longer writable. Returns the new event id, or null. */
     suspend fun createEvent(event: NewCalendarEvent): String?
 }
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
@@ -274,7 +274,11 @@ interface Calendar {
     fun calendars(): Flow<List<CalendarEntity>>
     fun updateCalendarEnabled(calendarId: Int, enabled: Boolean)
 
-    /** Create an event in the device's primary/default calendar. Returns the new event id, or null. */
+    /** Calendars the user can create events in, the phone's default for new events first. */
+    suspend fun writableCalendars(): List<CalendarEntity>
+
+    /** Create an event in [NewCalendarEvent.calendarId], or the phone's default calendar when
+     *  that is null. Returns the new event id, or null. */
     suspend fun createEvent(event: NewCalendarEvent): String?
 }
 

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/calendar/WritableCalendarTargetTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/calendar/WritableCalendarTargetTest.kt
@@ -1,0 +1,39 @@
+package io.rebble.libpebblecommon.calendar
+
+import io.rebble.libpebblecommon.database.entity.CalendarEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private fun calendar(platformId: String) = CalendarEntity(
+    platformId = platformId,
+    name = "Work",
+    ownerName = "Owner",
+    ownerId = "owner",
+    color = 0,
+    enabled = true,
+)
+
+class WritableCalendarTargetTest {
+    private val calendars = listOf(calendar("1"), calendar("2"), calendar("3"))
+
+    @Test
+    fun usesTheRequestedCalendar() {
+        assertEquals("2", calendars.resolveWritableTarget("2")?.platformId)
+    }
+
+    @Test
+    fun noChoiceUsesTheDefault() {
+        assertEquals("1", calendars.resolveWritableTarget(null)?.platformId)
+    }
+
+    @Test
+    fun goneCalendarFallsBackToTheDefault() {
+        assertEquals("1", calendars.resolveWritableTarget("99")?.platformId)
+    }
+
+    @Test
+    fun noWritableCalendars() {
+        assertNull(emptyList<CalendarEntity>().resolveWritableTarget("1"))
+    }
+}

--- a/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/calendar/IosSystemCalendar.kt
+++ b/libpebble3/src/iosMain/kotlin/io/rebble/libpebblecommon/calendar/IosSystemCalendar.kt
@@ -79,16 +79,17 @@ class IosSystemCalendar(
         val ek = eventStore() ?: return emptyList()
         val calendars =
             ek.calendarsForEntityType(EKEntityType.EKEntityTypeEvent) as List<EKCalendar>
-        return calendars.map {
-            CalendarEntity(
-                platformId = it.calendarIdentifier,
-                name = it.title,
-                ownerName = it.source?.title ?: "unknown",
-                ownerId = it.source?.sourceIdentifier ?: "unknown",
-                color = it.CGColor?.cgColorToInt() ?: 0,
-                enabled = true,
-            )
-        }
+        return calendars.map { it.asEntity() }
+    }
+
+    override suspend fun getWritableCalendars(): List<CalendarEntity> {
+        val ek = eventStore() ?: return emptyList()
+        val defaultId = ek.defaultCalendarForNewEvents?.calendarIdentifier
+        val calendars =
+            ek.calendarsForEntityType(EKEntityType.EKEntityTypeEvent) as List<EKCalendar>
+        return calendars.filter { it.allowsContentModifications }
+            .map { it.asEntity() }
+            .sortedByDescending { it.platformId == defaultId }
     }
 
     override suspend fun getCalendarEvents(
@@ -188,9 +189,10 @@ class IosSystemCalendar(
 
     override suspend fun createEvent(event: NewCalendarEvent): String? {
         val ek = eventStore() ?: return null
-        val calendar = ek.defaultCalendarForNewEvents
+        val calendar = getWritableCalendars().resolveWritableTarget(event.calendarId)
+            ?.let { ek.calendarWithIdentifier(it.platformId) }
         if (calendar == null) {
-            logger.e { "No default calendar for new events" }
+            logger.e { "No writable calendar for new events" }
             return null
         }
         val ekEvent = EKEvent.eventWithEventStore(ek)
@@ -218,6 +220,15 @@ class IosSystemCalendar(
 
     override fun supportsPinActions(): Boolean = false
 }
+
+private fun EKCalendar.asEntity(): CalendarEntity = CalendarEntity(
+    platformId = calendarIdentifier,
+    name = title,
+    ownerName = source?.title ?: "unknown",
+    ownerId = source?.sourceIdentifier ?: "unknown",
+    color = CGColor?.cgColorToInt() ?: 0,
+    enabled = true,
+)
 
 fun EKAlarm.asReminder(): EventReminder = EventReminder.fromStartOffset(relativeOffset)
 


### PR DESCRIPTION
## Problem

Closes #350 

Connecting the Phone Calendar integration only grants calendar permission and flips a boolean. Events go to whatever calendar the platform picked, with no indication to the user. Most users have many calendars, and there's no guarantee the phone is offering Pebble the "right" one.

## Solution

This PR changes the UI for calendar integration, so the user can select from all known calendars. It also changes display to show which calendar is active.

## Changes

- `SystemCalendar.getWritableCalendars()`: lists calendars the user can create events in, platform default first. Android filters on `CALENDAR_ACCESS_LEVEL >= CAL_ACCESS_CONTRIBUTOR` and puts the account's own calendar first using the existing `findPrimaryWritableCalendarId`. iOS filters on `allowsContentModifications` and puts `defaultCalendarForNewEvents` first.
- `NewCalendarEvent.calendarId`: the calendar to write to. `createEvent` uses it when it's still writable and falls back to the default when it's null or the calendar has gone away (account removed), otherwise a stale selection would silently break event creation.
- Ring `Preferences.phoneCalendarId` stores the choice; `CreateCalendarEventTool` passes it through.
- `PhoneCalendarPicker`, a radio list of writable calendars with their account, shown when connecting the integration (Accounts → Add integration → Phone Calendar) and in its manage dialog. It defaults to the platform default, which is the first entry. 

Both platforms are covered; the Android provider query moved to `Dispatchers.IO` since the settings UI now calls it.

## Testing

- CI green (`android` + `ios`): `assembleDebug testDebugUnitTest testAndroidHostTest jvmTest lintDebug`.
- `WritableCalendarTargetTest` (commonTest) covers target resolution: requested calendar, no choice, calendar gone, no writable calendars.
- `OwnAccountFirstTest` (androidHostTest) covers the Android primary-calendar ordering, including that a row with no account name isn't treated as the account's own.

## manual testing

Not done. I'm a very seasoned developer professionally but not for mobile; i don't have any kind of real build environment set up outside of the included CI. I also have no access to an iOS device. Since this change is so small and architecturally straightforward, I felt comfortable reviewing and  contributing it. 

This is entirely written through claude, with separate reviews both by me and by copilot. 