### PR TITLE
Add optional 'required' flag to companionApp appinfo declaration

### DIFF
--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKit2.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKit2.kt
@@ -72,16 +72,18 @@ class PebbleKit2(
             if (connectSuccess) {
                 launchIncomingAppMessageHandler(scope, incomingAppMessages)
             } else {
-                val appName = appInfo.shortName
-                val downloadUrl = appInfo.companionApp?.android?.url
-                errorTracker.reportError(
-                    UserFacingError.MissingCompanionApp(
-                        "$appName needs a companion app to function properly",
-                        appName,
-                        uuid,
-                        downloadUrl
+                if (appInfo.companionApp?.android?.required != false) {
+                    val appName = appInfo.shortName
+                    val downloadUrl = appInfo.companionApp?.android?.url
+                    errorTracker.reportError(
+                        UserFacingError.MissingCompanionApp(
+                            "$appName needs a companion app to function properly",
+                            appName,
+                            uuid,
+                            downloadUrl
+                        )
                     )
-                )
+                }
                 if (!pkjsRunning) {
                     // Don't auto-NACK if PKJS is running
                     launchNackAllIncomingMessages(scope, incomingAppMessages)

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/metadata/pbw/appinfo/AndroidCompanionAppRoot.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/metadata/pbw/appinfo/AndroidCompanionAppRoot.kt
@@ -5,5 +5,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AndroidCompanionAppRoot(
     val url: String? = null,
-    val apps: List<AndroidCompanionAppInstance> = emptyList()
+    val apps: List<AndroidCompanionAppInstance> = emptyList(),
+    /**
+     * Whether the watchapp needs the companion app to function. When false, the companion only
+     * enhances the watchapp (e.g. alongside PKJS), so no error is surfaced if it isn't installed.
+     */
+    val required: Boolean = true,
 )


### PR DESCRIPTION
Watchapps that use PKJS as their primary companion can declare a PebbleKit 2 companion package purely as an optional enhancement. Today, declaring companionApp.android.apps causes a "needs a companion app to function properly" error every time the watchapp starts without the companion installed, even though AppMessages continue to flow to PKJS.

Setting "required": false in the pbw's companionApp.android block suppresses that error. Defaults to true, so existing pbws are unaffected, and the appinfo parser already ignores unknown keys on older app versions.

**Why I need this**:
I am working on a companion app that will add additional functionality to my Pebble watch app but will not be required. 