### PR TITLE
Timeline emulator: honor openWatchApp pin actions with launch codes

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/TimelineItemDsl.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/TimelineItemDsl.kt
@@ -128,6 +128,10 @@ class AttributesListBuilder internal constructor() {
         attributes.add(BaseAttribute.UIntAttribute(TimelineAttribute.LastUpdated, block().epochSeconds.toUInt()))
     }
 
+    fun launchCode(block: () -> UInt) {
+        attributes.add(BaseAttribute.UIntAttribute(TimelineAttribute.LaunchCode, block()))
+    }
+
     fun appName(block: () -> String) {
         string(TimelineAttribute.AppName, block)
     }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/RemoteTimelineEmulator.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/RemoteTimelineEmulator.kt
@@ -173,12 +173,19 @@ private fun asPin(jsonPin: TimelinePinJson, appUuid: Uuid, pinUuid: Uuid): Timel
         actions {
             jsonPin.actions?.forEach { a ->
                 val actionType = a.type.asActionType()
-                if (actionType == null) {
-                    logger.w { "Unknown action type: ${a.type}" }
-                } else {
-//                    action(actionType) {
-//                        // TODO developer actions
-//                    }
+                when (actionType) {
+                    null -> logger.w { "Unknown action type: ${a.type}" }
+                    // Handled entirely on the watch: launches the pin's parent app with
+                    // the launch code in launch_get_args().
+                    TimelineItem.Action.Type.OpenWatchapp -> action(actionType) {
+                        attributes {
+                            title { a.title }
+                            a.launchCode?.let { code -> launchCode { code } }
+                        }
+                    }
+                    // Anything invoked on the phone without a handler shows "Failed" on
+                    // the watch (TimelineActionManager), so don't offer it.
+                    else -> logger.w { "Dropping unsupported action type: ${a.type}" }
                 }
             }
             action(TimelineItem.Action.Type.Remove) {
@@ -246,6 +253,8 @@ data class TimelineReminderJson(
 data class TimelineActionJson(
     val title: String,
     val type: String,
+    /** uint32 passed to the watchapp via launch args (openWatchApp actions only). */
+    val launchCode: UInt? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

`RemoteTimelineEmulator.asPin()` parses developer actions from pin JSON and then throws them away — the emit is commented out as `// TODO developer actions` — so every emulated pin gets only the auto-added "Remove". This restores `openWatchApp` actions, the classic timeline behavior where tapping a pin's action launches the watchapp that owns the pin, with a launch code the app can use to deep-link (e.g. a calendar app opening the exact event the pin represents).

- `TimelineActionJson` gains an optional `launchCode: UInt?`, matching the [classic timeline API pin schema](https://developer.repebble.com/guides/pebble-timeline/pin-structure/).
- `asPin()` now emits `openWatchApp` actions with their title and a `LaunchCode` attribute (new `launchCode {}` helper in the attributes DSL, mirroring `lastUpdated {}`).

No firmware or serialization work is needed: `TimelineAttribute.LaunchCode` (0x0D) already exists and serializes as a 4-byte LE uint, and firmware handles `OpenWatchApp` entirely on-watch — `timeline.c` resolves the pin's `parent_id`, reads `AttributeIdLaunchCode` off the action, and launches the app with `APP_LAUNCH_TIMELINE_ACTION`, so the app sees the code in `launch_get_args()`.

## Why only openWatchApp

`OpenWatchApp` never round-trips to the phone, so it works end to end today. Other developer action types (`http`, generic) invoked on the phone land in `TimelineActionManager.handlePinAction`, which has no handler for them and returns a failed result — the watch shows "Failed". Offering those buttons would only mislead, so they're still dropped, now with a log line. They can gain real handlers in follow-ups.

## Testing

- Built `:libpebble3:compileAndroidMain`.
- Verified against firmware source that the emitted BlobDB action record matches what `timeline_actions.c`/`timeline.c` expect (action type 0x07, 4-byte LE launch code attribute on the action, not the pin).

Related: #258 forwards PebbleKit2 reminders through this same path; a follow-up can map PebbleKit2 pin actions into `TimelineActionJson` the same way once the PebbleKit2 model gains actions (PR open on pebble-dev/PebbleKitAndroid2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)