### PR TITLE
ci: use latest actions/setup-java with actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,20 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Cache build deps
-        uses: actions/cache@v4
+      - name: Setup JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: android-deps-${{ runner.os }}-${{ hashFiles('gradle/**', 'gradlew*', 'gradle.properties', '*.gradle*') }}
-          restore-keys: |
-            android-deps-${{ runner.os }}-
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
       - name: Use dummy google-services json
         run: mv androidApp/src/google-services-dummy.json androidApp/src/google-services.json
       - name: Build and Test
@@ -40,25 +35,19 @@ jobs:
   ios:
     runs-on: macos-15
     steps:
+      - name: Checkout source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: 17
-      - name: Checkout source
-        uses: actions/checkout@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
-          submodules: recursive
-      - name: Cache build deps
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-          key: ios-deps-${{ runner.os }}-${{ hashFiles('gradle/**', 'gradlew*', 'gradle.properties', '*.gradle*') }}
-          restore-keys: |
-            ios-deps-${{ runner.os }}-
+          cache-provider: basic
       - name: Set up Xcode
         run: |
           ls /Applications/Xcode*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,21 +8,17 @@ jobs:
   publish-swift:
     runs-on: macos-latest
     steps:
-      - name: Setup JDK
-        uses: actions/setup-java@v1.4.4
-        with:
-          java-version: 21
       - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Cache build deps
-        uses: actions/cache@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.konan/cache
-            ~/.konan/dependencies
-          key: build-deps-${{ runner.os }}-${{ hashFiles('gradle/**', 'gradlew*', 'gradle.properties', '*.gradle*') }}
-
+          distribution: 'temurin'
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
       - name: Build XCFrameworks
         run: ./gradlew assembleXCFramework
 
@@ -46,7 +42,7 @@ jobs:
           echo RELEASE_CHECKSUM=$(swift package compute-checksum build/xcframework.zip) >> $GITHUB_ENV
 
       - name: Checkout master
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: 'master'
 
@@ -68,21 +64,17 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Setup JDK
-        uses: actions/setup-java@v1.4.4
-        with:
-          java-version: 17
-      - name: Cache build deps
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.konan/cache
-            ~/.konan/dependencies
-          key: build-deps-${{ hashFiles('~/.gradle/**') }}-${{ hashFiles('~/.konan/**') }}
-
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.
+      - name: Setup JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
 
       - name: Publish artifact
         env:


### PR DESCRIPTION
- there was a new `distribution` key required for the versions moving from v1
- pinned the version to the commit hash for security. Should be easy to be kept up-to-date with the separate PR that adds Dependabot
- hoist the actions/checkout before the java setup, so the gradle files are availble to figure out the cache key
- dropped the actions/cache setup, since it is built-in/bundled witht the actions/setup-java config. It did drop the `.konan` folders, but that could be added back as part of `cache-dependency-path` from https://github.com/actions/setup-java#inputs