### PR TITLE
Validate mcp server name will survive composite tool name round-trip

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/mcp/McpServers.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/mcp/McpServers.kt
@@ -402,7 +402,7 @@ internal fun HttpServerEditDialog(
                 isError = !nameIsValid,
                 supportingText = when {
                     !nameIsValid -> {
-                        { Text("Letters, digits, - and _ only: the name is part of every tool name sent to the model") }
+                        { Text("Name can only contain letters, digits, - and _ characters") }
                     }
                     else -> {
                         { Text("") }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/mcp/McpServers.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/mcp/McpServers.kt
@@ -402,7 +402,7 @@ internal fun HttpServerEditDialog(
                 isError = !nameIsValid,
                 supportingText = when {
                     !nameIsValid -> {
-                        { Text("Name can only contain letters, digits, - and _ characters") }
+                        { Text("Name can only contain letters, digits, - and _ characters, up to 32") }
                     }
                     else -> {
                         { Text("") }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/mcp/McpServers.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/mcp/McpServers.kt
@@ -49,6 +49,7 @@ import coredevices.indexai.data.entity.mcp_sandbox.McpSandboxGroupEntity
 import coredevices.indexai.data.entity.mcp_sandbox.SandboxModelType
 import coredevices.mcp.client.HttpMcpIntegration
 import coredevices.mcp.client.HttpMcpProtocol
+import coredevices.mcp.client.isValidIntegrationName
 import coredevices.mcp.data.McpPrompt
 import coredevices.ring.agent.IndexAction
 import coredevices.ring.database.room.repository.McpServerEntry
@@ -349,7 +350,8 @@ internal fun HttpServerEditDialog(
     // Only Name and URL are required. Contactability is advisory (surfaced as an error below)
     // but must not gate saving: a server may be momentarily down, need auth entered here, or
     // simply not respond to the title probe while still being a valid entry to create.
-    val canSave = name.isNotBlank() && url.isNotBlank()
+    val nameIsValid = name.isBlank() || isValidIntegrationName(name)
+    val canSave = name.isNotBlank() && nameIsValid && url.isNotBlank()
 
     M3Dialog(
         onDismissRequest = onDismiss,
@@ -397,6 +399,15 @@ internal fun HttpServerEditDialog(
                 value = name,
                 onValueChange = { name = it },
                 label = { Text("Name") },
+                isError = !nameIsValid,
+                supportingText = when {
+                    !nameIsValid -> {
+                        { Text("Letters, digits, - and _ only: the name is part of every tool name sent to the model") }
+                    }
+                    else -> {
+                        { Text("") }
+                    }
+                },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = dismissKeyboard,

--- a/mcp/src/commonMain/kotlin/coredevices/mcp/client/McpSession.kt
+++ b/mcp/src/commonMain/kotlin/coredevices/mcp/client/McpSession.kt
@@ -111,9 +111,14 @@ data class McpSessionTool(
 
 /**
  * Integration names must survive round-trip through the model as part of a composite tool name.
- * Validate it won't get changed by the tool-name sanitizer and doesn't use the "__" separator.
+ * Validate it won't get changed by the tool-name sanitizer, doesn't use the "__" separator, and
+ * leaves the tool half room inside the sanitizer's 64 character limit.
  */
 fun isValidIntegrationName(name: String): Boolean =
-    INTEGRATION_NAME_REGEX.matches(name) && !name.contains("__")
+    name.length <= MAX_INTEGRATION_NAME_LENGTH &&
+        INTEGRATION_NAME_REGEX.matches(name) &&
+        !name.contains("__")
+
+private const val MAX_INTEGRATION_NAME_LENGTH = 32
 
 private val INTEGRATION_NAME_REGEX = Regex("[A-Za-z0-9_-]+")

--- a/mcp/src/commonMain/kotlin/coredevices/mcp/client/McpSession.kt
+++ b/mcp/src/commonMain/kotlin/coredevices/mcp/client/McpSession.kt
@@ -110,11 +110,8 @@ data class McpSessionTool(
 )
 
 /**
- * Integration names round-trip through the model as part of a composite tool name -
- * "integration__tool" for Nenya, "integration.tool" for Cactus - and are split back out to
- * look the integration up again. A name carrying anything the providers' tool-name sanitizer
- * rewrites, or a second separator, no longer matches the key it was stored under, so the call
- * fails here as "Unknown tool name" before any request reaches the server.
+ * Integration names must survive round-trip through the model as part of a composite tool name.
+ * Validate it won't get changed by the tool-name sanitizer and doesn't use the "__" separator.
  */
 fun isValidIntegrationName(name: String): Boolean =
     INTEGRATION_NAME_REGEX.matches(name) && !name.contains("__")

--- a/mcp/src/commonMain/kotlin/coredevices/mcp/client/McpSession.kt
+++ b/mcp/src/commonMain/kotlin/coredevices/mcp/client/McpSession.kt
@@ -108,3 +108,15 @@ data class McpSessionTool(
     val integrationName: String,
     val tool: McpTool
 )
+
+/**
+ * Integration names round-trip through the model as part of a composite tool name -
+ * "integration__tool" for Nenya, "integration.tool" for Cactus - and are split back out to
+ * look the integration up again. A name carrying anything the providers' tool-name sanitizer
+ * rewrites, or a second separator, no longer matches the key it was stored under, so the call
+ * fails here as "Unknown tool name" before any request reaches the server.
+ */
+fun isValidIntegrationName(name: String): Boolean =
+    INTEGRATION_NAME_REGEX.matches(name) && !name.contains("__")
+
+private val INTEGRATION_NAME_REGEX = Regex("[A-Za-z0-9_-]+")

--- a/mcp/src/jvmTest/kotlin/coredevices/mcp/client/IntegrationNameTest.kt
+++ b/mcp/src/jvmTest/kotlin/coredevices/mcp/client/IntegrationNameTest.kt
@@ -34,4 +34,12 @@ class IntegrationNameTest {
     fun rejectsEmptyName() {
         assertFalse(isValidIntegrationName(""))
     }
+
+    @Test
+    fun rejectsNamesThatCrowdOutTheToolHalf() {
+        // sanitizeToolName truncates "$name__$tool" at 64 characters, which silently
+        // rewrites the tool half rather than the name.
+        assertTrue(isValidIntegrationName("a".repeat(32)))
+        assertFalse(isValidIntegrationName("a".repeat(33)))
+    }
 }

--- a/mcp/src/jvmTest/kotlin/coredevices/mcp/client/IntegrationNameTest.kt
+++ b/mcp/src/jvmTest/kotlin/coredevices/mcp/client/IntegrationNameTest.kt
@@ -1,0 +1,37 @@
+package coredevices.mcp.client
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IntegrationNameTest {
+    @Test
+    fun acceptsNamesThatSurviveTheCompositeRoundTrip() {
+        assertTrue(isValidIntegrationName("plexmcp"))
+        assertTrue(isValidIntegrationName("plex-mcp"))
+        assertTrue(isValidIntegrationName("plex_mcp"))
+    }
+
+    @Test
+    fun rejectsDotsWhichCactusSplitsOn() {
+        // "plex.mcp" + "." + "get_libraries" splits back into "plex" and the rest.
+        assertFalse(isValidIntegrationName("plex.mcp"))
+        assertFalse(isValidIntegrationName("plex-mcp.germany.vertesi.com"))
+    }
+
+    @Test
+    fun rejectsCharactersNenyaWouldSanitize() {
+        assertFalse(isValidIntegrationName("plex mcp"))
+        assertFalse(isValidIntegrationName("plex/mcp"))
+    }
+
+    @Test
+    fun rejectsASecondNenyaSeparator() {
+        assertFalse(isValidIntegrationName("plex__mcp"))
+    }
+
+    @Test
+    fun rejectsEmptyName() {
+        assertFalse(isValidIntegrationName(""))
+    }
+}


### PR DESCRIPTION
Closes #345  

An HTTP MCP server's **Name** is free text, and it is used verbatim as the key in `McpSession.integrationLookup`. But the agent receives it in a composite tool name, and decomposes to actually route the call:

| Agent | Composite sent to model | Decoded by |
|---|---|---|
| Nenya | `"$integration__$tool"`, then `[^a-zA-Z0-9_-]` → `_` (`AgentNenya.sanitizeToolName`) | `split("__", limit = 2)` |
| Cactus | `"$parent.$shortName"` (`IndexAgentCactus`) | `split(".", limit = 2)` |

If the tool name is changed in that compose/decompose round trip, the name called doesn't match the name stored. Every tool call fails with "Invalid tool call", after `connect()` initializes the session, and the server logs nothing.  This is hard to diagnose: the server is healthy, the connection test passes, and tools list fine.

This is expected to be a common failure because it can be triggered by naming a server after its hostname. An MCP stored with name `my-mcp.example.com` + tool `get_libraries` is called by name `my-mcp` and tool `example.com.get_libraries`.

## Changes

- `isValidIntegrationName()` next to `McpSession` to validate the lookup.
- The Name field gets `isError` + supporting text, required by `canSave`.

Blank (or fresh dialog) doesn't trigger the error flag, but `canSave` requires non-blank for submit. Editing an existing entry with a bad name shows the error and blocks save until it's fixed. 

Note that `sanitizeToolName` also does `.take(64)`, so a long name plus a long tool name truncates the *tool* half. We can't protect against that completely since the tool names are unknown until the form is filled. I arbitrarily set a max length of 32 chars to leave space for tool names. This failure mode isn't so bad; it only hits individual tools, and it shows up in the server  logs.

## Not changed

The proper fix would be to route on a stable id rather than the display name, which would let names be anything. But that requires a refactor across both agents and their decode paths... too big for a drive-by PR. :) 

## Testing

`IntegrationNameTest` covers the accepted forms and each rejected class in the style of the existing `mcp/src/jvmTest` cases.

## AI disclosure

This change was written with Claude Code. The diagnosis came from reading `AgentNenya`, `IndexAgentCactus` and `McpSession` against a live server's logs. The root cause and mitigation was confirmed against my own real-world failing setup before any code was written.

I'm a very seasoned developer professionally but not for mobile; i don't have any kind of real build environment set up outside of the included CI. I also have no access to an iOS device. Since this change is so small and architecturally straightforward, I felt comfortable reviewing and contributing it.