### PR TITLE
Notesnook support for both reminders and notes.

### DIFF
--- a/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
+++ b/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
@@ -672,6 +672,30 @@ class RingRecordingE2ETest {
                 )
             }
         } bind IndexWebhookApi::class
+        single {
+            object : coredevices.ring.external.indexlocal.IndexLocalCaptureApi {
+                override fun deliverIfEnabled(
+                    samples: ShortArray?,
+                    sampleRate: Int,
+                    recordingId: String,
+                    transcription: String?,
+                    recordedAt: Instant,
+                    gesture: coredevices.ring.service.button.RingGesture,
+                ) {}
+                override fun deliverReminder(
+                    title: String,
+                    deadline: kotlin.time.Instant?,
+                    notifyBefore: kotlin.time.Duration?,
+                    recordingId: String,
+                    recordedAt: Instant,
+                ) {}
+                override fun isCapturingRecording() = false
+                override fun beginRecordingCapture() {}
+                override fun endRecordingCapture() {}
+                override fun isNotesnookInstalled() = false
+            }
+        } bind coredevices.ring.external.indexlocal.IndexLocalCaptureApi::class
+        singleOf(::coredevices.ring.external.indexlocal.IndexLocalAppPreferences)
         single<com.russhwolf.settings.Settings> {
             SharedPreferencesSettings(context.getSharedPreferences("e2e_test_prefs", Context.MODE_PRIVATE))
         }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" tools:node="remove" />
     <!-- Mixpanel -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="com.streetwriters.notesnook.permission.RECEIVE_INDEX_CAPTURE" />
+    <queries>
+        <package android:name="com.streetwriters.notesnook" />
+    </queries>
     <application
         android:name=".MainApplication"
         android:usesCleartextTraffic="true"

--- a/androidApp/src/main/res/xml/filepaths.xml
+++ b/androidApp/src/main/res/xml/filepaths.xml
@@ -13,6 +13,6 @@
         name="screenshots"
         path="screenshots/" />
     <cache-path
-        name="bugreports"
-        path="bugreports/" />
+        name="index_local"
+        path="index-local/" />
 </paths>

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
@@ -266,7 +266,6 @@ fun OnboardingScreen(
                 }
 
                 OnboardingStage.SignIn -> {
-                    val coreConfig by viewModel.coreConfig.collectAsState()
                     Column(
                         modifier = Modifier.fillMaxSize().padding(20.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -286,13 +285,20 @@ fun OnboardingScreen(
                             // to the existing account if Firebase reports a collision.
                             skipAccountSwitchConfirmation = true,
                         )
-                        if (!coreConfig.enableIndex) {
-                            PebbleElevatedButton(
-                                text = "Skip",
-                                onClick = { viewModel.stage.value = OnboardingStage.Done },
-                                primaryColor = true,
-                            )
-                        }
+                        Spacer(modifier = Modifier.height(16.dp))
+                        PebbleElevatedButton(
+                            text = "Continue without signing in",
+                            onClick = { viewModel.stage.value = OnboardingStage.Done },
+                            primaryColor = false,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Cloud backup and the remote agent need an account. " +
+                                "You can sign in later from Settings.",
+                            textAlign = TextAlign.Center,
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                        )
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/ringonboarding/SignInStep.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/ringonboarding/SignInStep.kt
@@ -69,7 +69,7 @@ internal fun SignInStep(
             }
             Spacer(Modifier.height(40.dp))
             Text(
-                text = "Sign in to continue",
+                text = if (signedIn) "You're signed in" else "Sign in (optional)",
                 fontSize = 32.sp,
                 lineHeight = 38.sp,
                 fontWeight = FontWeight.ExtraBold,
@@ -78,8 +78,12 @@ internal fun SignInStep(
             )
             Spacer(Modifier.height(16.dp))
             Text(
-                text = "Index 01 needs an account for backup and agent processing. " +
-                        "Sign in to finish setting up your ring.",
+                text = if (signedIn) {
+                    "Index 01 can back up recordings and run the remote agent with this account."
+                } else {
+                    "An account is only needed for cloud backup and the remote agent. " +
+                        "Local recording, transcription, and Notesnook work without signing in."
+                },
                 fontSize = 16.sp,
                 lineHeight = 24.sp,
                 color = palette.onSurfaceVariant,
@@ -122,7 +126,10 @@ internal fun SignInStep(
                 .fillMaxWidth()
                 .padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 16.dp),
         ) {
-            PrimaryFilledButton(text = "Continue", onClick = onContinue, enabled = signedIn)
+            PrimaryFilledButton(
+                text = if (signedIn) "Continue" else "Continue without signing in",
+                onClick = onContinue,
+            )
         }
     }
 }

--- a/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
+++ b/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
@@ -270,6 +270,30 @@ class RecordingProcessingQueueTest {
                 )
             }
         } bind IndexWebhookApi::class
+        single {
+            object : coredevices.ring.external.indexlocal.IndexLocalCaptureApi {
+                override fun deliverIfEnabled(
+                    samples: ShortArray?,
+                    sampleRate: Int,
+                    recordingId: String,
+                    transcription: String?,
+                    recordedAt: Instant,
+                    gesture: coredevices.ring.service.button.RingGesture,
+                ) {}
+                override fun deliverReminder(
+                    title: String,
+                    deadline: kotlin.time.Instant?,
+                    notifyBefore: kotlin.time.Duration?,
+                    recordingId: String,
+                    recordedAt: Instant,
+                ) {}
+                override fun isCapturingRecording() = false
+                override fun beginRecordingCapture() {}
+                override fun endRecordingCapture() {}
+                override fun isNotesnookInstalled() = false
+            }
+        } bind coredevices.ring.external.indexlocal.IndexLocalCaptureApi::class
+        singleOf(::coredevices.ring.external.indexlocal.IndexLocalAppPreferences)
         singleOf(::IndexWebhookPreferences)
 
         single { CoreConfigFlow(MutableStateFlow(CoreConfig())) }

--- a/experimental/src/androidMain/AndroidManifest.xml
+++ b/experimental/src/androidMain/AndroidManifest.xml
@@ -40,6 +40,8 @@
         <package android:name="com.beeper.android"/>
         <!-- Tasker integration checks for/launches the Tasker app (package visibility, Android 11+). -->
         <package android:name="net.dinglisch.android.taskerm"/>
+        <!-- Notesnook local Index capture (explicit service/broadcast, Android 11+ package visibility). -->
+        <package android:name="com.streetwriters.notesnook"/>
     </queries>
     <application>
         <receiver android:name=".glance.VoiceWidgetReceiver"

--- a/experimental/src/androidMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookNoteClient.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookNoteClient.android.kt
@@ -1,0 +1,56 @@
+package coredevices.ring.agent.builtin_servlets.notes
+
+import PlatformUiContext
+import coredevices.ring.agent.integrations.ItemSource
+import coredevices.ring.agent.integrations.NoteIntegration
+import coredevices.ring.external.indexlocal.IndexLocalCaptureApi
+import coredevices.ring.service.button.RingGesture
+import coredevices.util.integrations.IntegrationTokenStorage
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import kotlin.time.Clock
+
+actual fun createNotesnookNoteClient(): NoteIntegration = NotesnookNoteClient()
+
+/**
+ * Routes notes to the Notesnook app on this phone via an explicit capture intent.
+ * Connecting records an opt-in flag; authorized only while opted in and installed.
+ * Agent-created notes send transcription only; ring recordings attach audio through
+ * [coredevices.ring.external.indexlocal.IndexLocalCaptureRecordingOperation].
+ */
+class NotesnookNoteClient : NoteIntegration, KoinComponent {
+    private val tokenStorage: IntegrationTokenStorage by inject()
+    private val api: IndexLocalCaptureApi by inject()
+
+    override suspend fun createNote(content: String, source: ItemSource?): String {
+        val recordingId = source?.recordingFirestoreId
+            ?: source?.toolCallId
+            ?: "note-${Clock.System.now().toEpochMilliseconds()}"
+        if (api.isCapturingRecording()) {
+            // The recording decorator sends one note with audio + transcript.
+            return recordingId
+        }
+        api.deliverIfEnabled(
+            samples = null,
+            sampleRate = 16000,
+            recordingId = recordingId,
+            transcription = content,
+            recordedAt = source?.createdAt ?: Clock.System.now(),
+            gesture = RingGesture.Hold,
+        )
+        return recordingId
+    }
+
+    override suspend fun signIn(uiContext: PlatformUiContext): Boolean {
+        if (!api.isNotesnookInstalled()) return false
+        tokenStorage.saveToken(NOTESNOOK_TOKEN_STORAGE_KEY, "enabled")
+        return true
+    }
+
+    override suspend fun unlink() {
+        tokenStorage.deleteToken(NOTESNOOK_TOKEN_STORAGE_KEY)
+    }
+
+    override suspend fun isAuthorized(): Boolean =
+        api.isNotesnookInstalled() && tokenStorage.getToken(NOTESNOOK_TOKEN_STORAGE_KEY) != null
+}

--- a/experimental/src/androidMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/NotesnookReminderIntegration.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/NotesnookReminderIntegration.android.kt
@@ -1,0 +1,66 @@
+package coredevices.ring.agent.builtin_servlets.reminders
+
+import PlatformUiContext
+import coredevices.ring.agent.builtin_servlets.notes.NOTESNOOK_TOKEN_STORAGE_KEY
+import coredevices.ring.agent.integrations.ItemSource
+import coredevices.ring.agent.integrations.ReminderIntegration
+import coredevices.ring.agent.integrations.ReminderListEntry
+import coredevices.ring.external.indexlocal.IndexLocalCaptureApi
+import coredevices.util.integrations.IntegrationTokenStorage
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+actual fun createNotesnookReminderIntegration(): ReminderIntegration = NotesnookReminderIntegration()
+
+/**
+ * Sends Index reminders to Notesnook as a note + reminder alarm via the same local capture
+ * intent as notes. Connecting shares the Notesnook opt-in token with [NotesnookNoteClient].
+ *
+ * [deadline] is forwarded as UTC epoch milliseconds and ISO-8601 (`Instant.toString()`).
+ * A null deadline becomes a permanent Notesnook reminder (no Once date).
+ */
+class NotesnookReminderIntegration : ReminderIntegration, KoinComponent {
+    private val tokenStorage: IntegrationTokenStorage by inject()
+    private val api: IndexLocalCaptureApi by inject()
+
+    override suspend fun createReminder(
+        title: String,
+        deadline: Instant?,
+        listId: String?,
+        notifyBefore: Duration?,
+        source: ItemSource?,
+    ): String {
+        val recordingId = source?.recordingFirestoreId
+            ?: source?.toolCallId
+            ?: "reminder-${Clock.System.now().toEpochMilliseconds()}"
+        api.deliverReminder(
+            title = title,
+            deadline = deadline,
+            notifyBefore = notifyBefore,
+            recordingId = recordingId,
+            recordedAt = source?.createdAt ?: Clock.System.now(),
+        )
+        return recordingId
+    }
+
+    override suspend fun searchForList(listName: String): List<ReminderListEntry> =
+        listOf(ReminderListEntry(id = listName, title = listName))
+
+    override suspend fun signIn(uiContext: PlatformUiContext): Boolean {
+        if (!api.isNotesnookInstalled()) return false
+        tokenStorage.saveToken(NOTESNOOK_TOKEN_STORAGE_KEY, "enabled")
+        return true
+    }
+
+    override suspend fun unlink() {
+        tokenStorage.deleteToken(NOTESNOOK_TOKEN_STORAGE_KEY)
+    }
+
+    override suspend fun isAuthorized(): Boolean =
+        api.isNotesnookInstalled() && tokenStorage.getToken(NOTESNOOK_TOKEN_STORAGE_KEY) != null
+
+    override suspend fun getAllLists(): List<ReminderListEntry> = emptyList()
+}

--- a/experimental/src/androidMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureApi.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureApi.android.kt
@@ -1,0 +1,320 @@
+package coredevices.ring.external.indexlocal
+
+import android.content.ClipData
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.util.Base64
+import androidx.core.content.FileProvider
+import co.touchlab.kermit.Logger
+import coredevices.ring.audio.M4aEncoder
+import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
+import coredevices.ring.service.RecordingBackgroundScope
+import coredevices.ring.service.button.RingGesture
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.io.File
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.time.TimeSource
+
+actual class IndexLocalCaptureApiImpl actual constructor(
+    private val m4aEncoder: M4aEncoder,
+    private val scope: RecordingBackgroundScope,
+) : IndexLocalCaptureApi, KoinComponent {
+
+    private val context: Context by inject()
+
+    companion object {
+        private val logger = Logger.withTag("IndexLocalCaptureApi")
+    }
+
+    @Volatile private var capturingRecording = false
+    @Volatile private var pendingReminder: PendingReminder? = null
+
+    private data class PendingReminder(
+        val title: String,
+        val deadline: Instant?,
+        val notifyBefore: Duration?,
+        val recordingId: String,
+        val recordedAt: Instant,
+    )
+
+    override fun isNotesnookInstalled(): Boolean = try {
+        context.packageManager.getPackageInfo(IndexLocalCaptureContract.NOTESNOOK_PACKAGE, 0)
+        true
+    } catch (_: PackageManager.NameNotFoundException) {
+        false
+    } catch (_: Exception) {
+        false
+    }
+
+    override fun isCapturingRecording(): Boolean = capturingRecording
+
+    override fun beginRecordingCapture() {
+        capturingRecording = true
+        pendingReminder = null
+    }
+
+    override fun endRecordingCapture() {
+        capturingRecording = false
+    }
+
+    override fun deliverIfEnabled(
+        samples: ShortArray?,
+        sampleRate: Int,
+        recordingId: String,
+        transcription: String?,
+        recordedAt: Instant,
+        gesture: RingGesture,
+    ) {
+        val reminder = pendingReminder
+        pendingReminder = null
+        scope.launch {
+            try {
+                val m4aData = samples?.let { m4aEncoder.encode(it, sampleRate) }
+                val result = deliver(
+                    gesture = gesture,
+                    recordingId = reminder?.recordingId ?: recordingId,
+                    transcription = transcription,
+                    recordedAt = recordedAt,
+                    audioData = m4aData,
+                    payloadMode = IndexWebhookPayloadMode.Both,
+                    isTest = false,
+                    kind = if (reminder != null) {
+                        IndexLocalCaptureContract.KIND_REMINDER
+                    } else {
+                        IndexLocalCaptureContract.KIND_NOTE
+                    },
+                    title = reminder?.title,
+                    deadline = reminder?.deadline,
+                    hasDeadline = reminder != null && reminder.deadline != null,
+                    notifyBeforeSeconds = reminder?.notifyBefore?.inWholeSeconds,
+                )
+                if (result.ok) {
+                    logger.i { "Local capture delivered $recordingId to Notesnook" }
+                } else {
+                    logger.e { "Local capture failed for $recordingId: ${result.status} ${result.detail}" }
+                }
+            } catch (e: Exception) {
+                logger.e(e) { "Error during local capture for $recordingId" }
+            }
+        }
+    }
+
+    override fun deliverReminder(
+        title: String,
+        deadline: Instant?,
+        notifyBefore: Duration?,
+        recordingId: String,
+        recordedAt: Instant,
+    ) {
+        if (capturingRecording) {
+            pendingReminder = PendingReminder(
+                title = title,
+                deadline = deadline,
+                notifyBefore = notifyBefore,
+                recordingId = recordingId,
+                recordedAt = recordedAt,
+            )
+            logger.i {
+                "Stashed reminder for recording capture title=$title deadlineMs=${deadline?.toEpochMilliseconds()} iso=${deadline?.toString()}"
+            }
+            return
+        }
+        scope.launch {
+            try {
+                val result = deliver(
+                    gesture = RingGesture.Hold,
+                    recordingId = recordingId,
+                    transcription = title,
+                    recordedAt = recordedAt,
+                    audioData = null,
+                    payloadMode = IndexWebhookPayloadMode.TranscriptionOnly,
+                    isTest = false,
+                    kind = IndexLocalCaptureContract.KIND_REMINDER,
+                    title = title,
+                    deadline = deadline,
+                    hasDeadline = deadline != null,
+                    notifyBeforeSeconds = notifyBefore?.inWholeSeconds,
+                )
+                if (result.ok) {
+                    logger.i {
+                        "Reminder delivered $recordingId deadline=${deadline?.toEpochMilliseconds()} iso=${deadline?.toString()}"
+                    }
+                } else {
+                    logger.e { "Reminder capture failed for $recordingId: ${result.status} ${result.detail}" }
+                }
+            } catch (e: Exception) {
+                logger.e(e) { "Error during reminder capture for $recordingId" }
+            }
+        }
+    }
+
+    private fun deliver(
+        gesture: RingGesture,
+        recordingId: String,
+        transcription: String?,
+        recordedAt: Instant,
+        audioData: ByteArray?,
+        payloadMode: IndexWebhookPayloadMode,
+        isTest: Boolean,
+        kind: String = IndexLocalCaptureContract.KIND_NOTE,
+        title: String? = null,
+        deadline: Instant? = null,
+        hasDeadline: Boolean = false,
+        notifyBeforeSeconds: Long? = null,
+    ): IndexLocalCaptureRunResult {
+        val started = TimeSource.Monotonic.markNow()
+        if (!isNotesnookInstalled()) {
+            return IndexLocalCaptureRunResult(
+                ok = false,
+                status = "NOT INSTALLED",
+                detail = "Notesnook is not installed",
+                byteSize = 0,
+                durationMs = started.elapsedNow().inWholeMilliseconds,
+            )
+        }
+
+        val audioUri: Uri? = audioData?.let { bytes ->
+            val dir = File(context.cacheDir, IndexLocalCaptureContract.CACHE_SUBDIR).apply { mkdirs() }
+            val file = File(dir, "$recordingId.m4a")
+            file.writeBytes(bytes)
+            FileProvider.getUriForFile(
+                context,
+                IndexLocalCaptureContract.FILE_PROVIDER_AUTHORITY,
+                file,
+            )
+        }
+
+        val payload = Intent(IndexLocalCaptureContract.ACTION).apply {
+            `package` = IndexLocalCaptureContract.NOTESNOOK_PACKAGE
+            putExtra(IndexLocalCaptureContract.EXTRA_RECORDED_AT, recordedAt.toEpochMilliseconds())
+            putExtra(IndexLocalCaptureContract.EXTRA_CLIENT, IndexLocalCaptureContract.CLIENT_RING)
+            putExtra(IndexLocalCaptureContract.EXTRA_RECORDING_ID, recordingId)
+            putExtra(
+                IndexLocalCaptureContract.EXTRA_TRIGGER,
+                if (isTest) IndexLocalCaptureContract.TRIGGER_TEST else gesture.localCaptureTriggerValue(),
+            )
+            putExtra(IndexLocalCaptureContract.EXTRA_PAYLOAD_MODE, payloadMode.wireName())
+            putExtra(IndexLocalCaptureContract.EXTRA_KIND, kind)
+            if (title != null) putExtra(IndexLocalCaptureContract.EXTRA_TITLE, title)
+            if (kind == IndexLocalCaptureContract.KIND_REMINDER) {
+                putExtra(IndexLocalCaptureContract.EXTRA_HAS_DEADLINE, hasDeadline)
+                if (deadline != null) {
+                    putExtra(
+                        IndexLocalCaptureContract.EXTRA_DEADLINE_EPOCH_MS,
+                        deadline.toEpochMilliseconds(),
+                    )
+                    putExtra(IndexLocalCaptureContract.EXTRA_DEADLINE_ISO, deadline.toString())
+                }
+                notifyBeforeSeconds?.let {
+                    putExtra(IndexLocalCaptureContract.EXTRA_NOTIFY_BEFORE_SECONDS, it)
+                }
+            }
+            if (isTest) putExtra(IndexLocalCaptureContract.EXTRA_TEST, true)
+            if (transcription != null) {
+                putExtra(IndexLocalCaptureContract.EXTRA_TRANSCRIPTION, transcription)
+            }
+            if (audioUri != null && audioData != null) {
+                // String extra survives startForegroundService even when ClipData /
+                // EXTRA_STREAM Uri parcelables are stripped on Android 13–17.
+                setDataAndType(audioUri, "audio/mp4")
+                putExtra(Intent.EXTRA_STREAM, audioUri)
+                putExtra(IndexLocalCaptureContract.EXTRA_AUDIO_URI, audioUri.toString())
+                putExtra(IndexLocalCaptureContract.EXTRA_AUDIO_SIZE, audioData.size)
+                // Binder extras are capped ~1 MB. Typical Index holds are well under
+                // this; URI copy is still preferred, this is a grant-stripping fallback.
+                if (audioData.size <= 400 * 1024) {
+                    putExtra(
+                        IndexLocalCaptureContract.EXTRA_AUDIO_BASE64,
+                        Base64.encodeToString(audioData, Base64.NO_WRAP),
+                    )
+                }
+                clipData = ClipData.newUri(context.contentResolver, "audio", audioUri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            } else {
+                type = "text/plain"
+            }
+        }
+
+        if (audioUri != null) {
+            context.grantUriPermission(
+                IndexLocalCaptureContract.NOTESNOOK_PACKAGE,
+                audioUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        }
+
+        val byteSize = (audioData?.size ?: 0).toLong() + (transcription?.length ?: 0)
+        fun targeted(className: String): Intent = Intent(payload).apply {
+            component = ComponentName(IndexLocalCaptureContract.NOTESNOOK_PACKAGE, className)
+            `package` = IndexLocalCaptureContract.NOTESNOOK_PACKAGE
+        }
+
+        fun ok(status: String) = IndexLocalCaptureRunResult(
+            ok = true,
+            status = status,
+            detail = contentsLabel(audioData != null, transcription != null),
+            byteSize = byteSize,
+            durationMs = started.elapsedNow().inWholeMilliseconds,
+        )
+
+        try {
+            val serviceIntent = targeted(IndexLocalCaptureContract.SERVICE_CLASS)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(serviceIntent)
+            } else {
+                context.startService(serviceIntent)
+            }
+            logger.i {
+                "Delivered $recordingId via capture service audio=${audioUri != null} bytes=${audioData?.size ?: 0}"
+            }
+            return ok("SERVICE")
+        } catch (serviceError: Exception) {
+            logger.w(serviceError) { "startForegroundService failed, trying activity trampoline" }
+        }
+
+        try {
+            val activityIntent = targeted(IndexLocalCaptureContract.ACTIVITY_CLASS).apply {
+                addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_NO_ANIMATION or
+                        Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+            context.startActivity(activityIntent)
+            logger.i { "Delivered $recordingId via capture activity" }
+            return ok("ACTIVITY")
+        } catch (activityError: Exception) {
+            logger.w(activityError) { "startActivity trampoline failed, trying broadcast" }
+        }
+
+        return try {
+            context.sendBroadcast(targeted(IndexLocalCaptureContract.RECEIVER_CLASS))
+            logger.i { "Delivered $recordingId via broadcast" }
+            ok("BROADCAST")
+        } catch (broadcastError: Exception) {
+            logger.e(broadcastError) { "Local capture broadcast also failed" }
+            IndexLocalCaptureRunResult(
+                ok = false,
+                status = "FAILED",
+                detail = broadcastError.message ?: "unknown error",
+                byteSize = byteSize,
+                durationMs = started.elapsedNow().inWholeMilliseconds,
+            )
+        }
+    }
+}
+
+private fun contentsLabel(hasAudio: Boolean, hasTranscription: Boolean): String = when {
+    hasAudio && hasTranscription -> "recording + transcription"
+    hasAudio -> "recording"
+    hasTranscription -> "transcription"
+    else -> "metadata only"
+}

--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -56,6 +56,10 @@ import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookApiImpl
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
 import coredevices.ring.external.indexwebhook.IndexWebhookRunRepository
+import coredevices.ring.agent.builtin_servlets.notes.NotesnookFromLocalAppsMigration
+import coredevices.ring.external.indexlocal.IndexLocalAppPreferences
+import coredevices.ring.external.indexlocal.IndexLocalCaptureApi
+import coredevices.ring.external.indexlocal.IndexLocalCaptureApiImpl
 import coredevices.ring.agent.integrations.obsidian.ObsidianPreferences
 import coredevices.ring.firestoreModule
 import coredevices.ring.mcpModule
@@ -91,6 +95,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
@@ -209,6 +214,7 @@ val experimentalModule = module {
     singleOf(::M4aEncoder)
     singleOf(::IndexWebhookPreferences)
     singleOf(::IndexWebhookRunRepository)
+    singleOf(::IndexLocalAppPreferences)
     singleOf(::GestureRoutingPreferences)
     singleOf(::ObsidianPreferences)
     single {
@@ -220,8 +226,19 @@ val experimentalModule = module {
             get<RecordingBackgroundScope>()
         )
     } bind IndexWebhookApi::class
+    single {
+        IndexLocalCaptureApiImpl(
+            get(),
+            get<RecordingBackgroundScope>()
+        )
+    } bind IndexLocalCaptureApi::class
 
     single { RecordingBackgroundScope(CoroutineScope(Dispatchers.IO + SupervisorJob())) }
+    single(createdAtStart = true) {
+        NotesnookFromLocalAppsMigration(get(), get(), get()).also { migration ->
+            get<RecordingBackgroundScope>().launch { migration.run() }
+        }
+    }
     single { RecordingProcessingQueue(get(), get(), get(), get(), get(), get(), get(), get()) }
     singleOf(::RecordingOperationFactory)
     singleOf(::RealRecordingStorage) bind RecordingStorage::class

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteIntegrationFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteIntegrationFactory.kt
@@ -24,6 +24,7 @@ class NoteIntegrationFactory(
             NoteProvider.Notion -> delegated(get<NotionIntegration>(), integration)
             NoteProvider.Obsidian -> delegated(get<ObsidianIntegration>(), integration)
             NoteProvider.Tasker -> delegated(createTaskerNoteClient(), integration)
+            NoteProvider.Notesnook -> delegated(createNotesnookNoteClient(), integration)
         }
     }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteProvider.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteProvider.kt
@@ -4,7 +4,8 @@ enum class NoteProvider(val id: Int, val title: String) {
     Builtin(1, "Builtin Notes"),
     Notion(2, "Notion"),
     Tasker(3, "Tasker"),
-    Obsidian(4, "Obsidian");
+    Obsidian(4, "Obsidian"),
+    Notesnook(5, "Notesnook");
 
     companion object {
         fun fromId(id: Int): NoteProvider? = entries.find { it.id == id }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookFromLocalAppsMigration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookFromLocalAppsMigration.kt
@@ -1,0 +1,25 @@
+package coredevices.ring.agent.builtin_servlets.notes
+
+import coredevices.ring.database.Preferences
+import coredevices.ring.external.indexlocal.IndexLocalAppPreferences
+import coredevices.util.integrations.IntegrationTokenStorage
+
+/**
+ * Users who turned on the old per-gesture "Local apps → Notesnook" toggle should keep
+ * receiving captures after Notesnook becomes a normal Notes destination.
+ */
+class NotesnookFromLocalAppsMigration(
+    private val localPrefs: IndexLocalAppPreferences,
+    private val prefs: Preferences,
+    private val tokenStorage: IntegrationTokenStorage,
+) {
+    suspend fun run() {
+        if (!localPrefs.anyEnabled()) return
+        if (tokenStorage.getToken(NOTESNOOK_TOKEN_STORAGE_KEY) == null) {
+            tokenStorage.saveToken(NOTESNOOK_TOKEN_STORAGE_KEY, "enabled")
+        }
+        if (prefs.noteProvider.value == NoteProvider.Builtin) {
+            prefs.setNoteProvider(NoteProvider.Notesnook)
+        }
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookNoteClient.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookNoteClient.kt
@@ -1,0 +1,20 @@
+package coredevices.ring.agent.builtin_servlets.notes
+
+import coredevices.ring.agent.builtin_servlets.reminders.ReminderProvider
+import coredevices.ring.agent.integrations.NoteIntegration
+import coredevices.ring.data.IntegrationDefinition
+
+/**
+ * Notesnook is an Android-only local notes app. Recordings are delivered with an explicit
+ * intent (audio + transcription, no internet). iOS returns a disabled stub so the provider
+ * never surfaces there.
+ */
+expect fun createNotesnookNoteClient(): NoteIntegration
+
+val NOTESNOOK_DEFINITION = IntegrationDefinition(
+    title = "Notesnook",
+    reminder = ReminderProvider.Notesnook,
+    notes = NoteProvider.Notesnook,
+)
+
+const val NOTESNOOK_TOKEN_STORAGE_KEY = "notesnook"

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/NotesnookReminderIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/NotesnookReminderIntegration.kt
@@ -1,0 +1,9 @@
+package coredevices.ring.agent.builtin_servlets.reminders
+
+import coredevices.ring.agent.integrations.ReminderIntegration
+
+/**
+ * Notesnook is Android-only. Reminders become a Notesnook note with an attached reminder
+ * alarm. iOS returns a disabled stub so the provider never surfaces there.
+ */
+expect fun createNotesnookReminderIntegration(): ReminderIntegration

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/ReminderIntegrationFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/ReminderIntegrationFactory.kt
@@ -24,6 +24,7 @@ class ReminderIntegrationFactory(
             ReminderProvider.GoogleTasks -> delegated(get<GTasksIntegration>(), provider)
             ReminderProvider.IOSReminders -> delegated(createRemindersAppIntegration(), provider)
             ReminderProvider.Tasker -> delegated(createTaskerReminderIntegration(), provider)
+            ReminderProvider.Notesnook -> delegated(createNotesnookReminderIntegration(), provider)
         }
     }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/ReminderProvider.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/ReminderProvider.kt
@@ -15,7 +15,9 @@ enum class ReminderProvider(val id: Int, val title: String) {
     /** The native iOS Reminders app (EventKit). iOS-only. */
     IOSReminders(3, "iPhone Reminders"),
     /** Routes reminders to the Tasker automation app via an intent. Android-only. */
-    Tasker(4, "Tasker");
+    Tasker(4, "Tasker"),
+    /** Routes reminders to Notesnook on this phone as a note + reminder. Android-only. */
+    Notesnook(5, "Notesnook");
 
     companion object {
         fun fromId(id: Int): ReminderProvider? = entries.find { it.id == id }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/ReminderTool.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/ReminderTool.kt
@@ -10,7 +10,6 @@ import coredevices.mcp.asFrozenClock
 import coredevices.mcp.data.SemanticResult
 import coredevices.mcp.data.ToolCallResult
 import coredevices.ring.agent.integrations.itemSource
-import coredevices.ring.ui.isLocale24HourFormat
 import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import io.modelcontextprotocol.kotlin.sdk.types.toJson
@@ -27,6 +26,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 
 class ReminderTool: BuiltInMcpTool(
     definition = Tool(
@@ -67,7 +67,7 @@ class ReminderTool: BuiltInMcpTool(
         )
     ),
     extraContext = """
-        Only pass times to 'create_reminder' that the user actually said. If the user started to specify a reminder time but it was cut off, do not guess one and do not create the reminder; tell the user the time was missing. Omit the time fields entirely for reminders without a time.
+        Always pass the time the user said in date_time_human or duration_human. Example: 'remind me to call mom at five p.m.' → message='call mom', date_time_human='at 5pm'. Omit the time fields only when the user gave no time at all.
     """.trimIndent()
 ), KoinComponent {
     val reminderIntegrationFactory: ReminderIntegrationFactory by inject()
@@ -95,119 +95,13 @@ class ReminderTool: BuiltInMcpTool(
 
     override suspend fun call(jsonInput: String, context: SessionContext): ToolCallResult {
         val remindArgs = JsonSnake.decodeFromString<RemindArgs>(jsonInput)
-        val instant = (remindArgs.date_time_human ?: remindArgs.duration_human)?.let { dateTimeHuman ->
-            val tz = TimeZone.currentSystemDefault()
-            // Anchor time resolution to when the user actually spoke. When that's unknown, only
-            // absolute times can fall back to the current clock; relative ones are refused.
-            val timeBase = context.timeBase
-            val anchor = timeBase ?: Clock.System.now()
-            val parser = HumanDateTimeParser(clock = anchor.asFrozenClock(), timeZone = tz)
-            val parsed = parser.parse(dateTimeHuman)
-            if (timeBase == null && parsed is InterpretedDateTime.Relative) {
-                return ToolCallResult(
-                    JsonSnake.encodeToString(
-                        RemindResult(
-                            success = false,
-                            errorMessage = "Cannot resolve relative time '$dateTimeHuman': the " +
-                                    "recording's original time is unknown. Use an absolute " +
-                                    "time, or create the reminder without a time."
-                        )
-                    ),
-                    SemanticResult.GenericFailure(
-                        "Couldn't determine when the recording was made",
-                        llmRecoverable = false
-                    )
-                )
-            }
-            when (parsed) {
-                is InterpretedDateTime.AbsoluteDate -> {
-                    logger.d { "Parsed absolute date: $parsed will assume 9am" }
-                    LocalDateTime(
-                        date = parsed.date,
-                        time = LocalTime(9, 0)
-                    )
-                }
-                is InterpretedDateTime.AbsoluteDateTime -> {
-                    logger.d { "Parsed absolute date time: $parsed" }
-                    parsed.dateTime
-                }
-                is InterpretedDateTime.AbsoluteTime -> {
-                    logger.d { "Parsed absolute time: $parsed" }
-                    val currentTime = anchor.toLocalDateTime(tz)
-                    if (parsed.time < currentTime.time) {
-                        val is12HourFormat = !isLocale24HourFormat()
-                        if (is12HourFormat && parsed.time.hour in 1..11 && !parsed.amPmExplicit) {
-                            // If the parsed time is in the past for today, and the locale is 12-hour format, there's a chance it was an AM/PM issue.
-                            // For example, if it's currently 3pm and the user said "at 3", it might have been parsed as 3am which has already passed.
-                            logger.d { "Parsed time is in the past and locale is 12-hour format, assuming it's an AM/PM parsing issue and adding 12 hours" }
-                            val correctedTime = LocalTime(
-                                hour = (parsed.time.hour + 12) % 24,
-                                minute = parsed.time.minute,
-                                second = parsed.time.second
-                            )
-
-                            if (correctedTime < currentTime.time) {
-                                logger.d { "Corrected time is still in the past, assuming it's for tomorrow" }
-                                LocalDateTime(
-                                    date = currentTime.date.plus(DatePeriod(days = 1)),
-                                    time = parsed.time
-                                )
-                            } else {
-                                logger.d { "Corrected time is not in the past, assuming it's for today" }
-                                LocalDateTime(
-                                    date = currentTime.date,
-                                    time = correctedTime
-                                )
-                            }
-                        } else {
-                            logger.d { "Parsed time has already passed today, assuming it's for tomorrow" }
-                            LocalDateTime(
-                                date = currentTime.date.plus(DatePeriod(days = 1)),
-                                time = parsed.time
-                            )
-                        }
-                    } else {
-                        logger.d { "Parsed time has not passed today, assuming it's for today" }
-                        LocalDateTime(
-                            date = currentTime.date,
-                            time = parsed.time
-                        )
-                    }
-                }
-                is InterpretedDateTime.Relative -> {
-                    logger.d { "Parsed relative date time: $parsed" }
-                    val currentTime = anchor
-                    val period = parsed.period
-                    if (period != null) {
-                        val local = currentTime.toLocalDateTime(tz)
-                        val newDate = local.date.plus(period)
-                        (LocalDateTime(newDate, local.time).toInstant(tz) + parsed.duration).toLocalDateTime(tz)
-                    } else {
-                        (currentTime + parsed.duration).toLocalDateTime(tz)
-                    }
-                }
-                null -> {
-                    logger.e { "Failed to parse date time: '$dateTimeHuman'" }
-                    return ToolCallResult(
-                        JsonSnake.encodeToString(
-                            RemindResult(
-                                success = false,
-                                errorMessage = "Failed to parse date time: '$dateTimeHuman'. " +
-                                        "Retry with the same date/time rephrased in simple English " +
-                                        "like 'on August 20 at 9am', 'tomorrow at 13:00' or 'in 2 hours'. " +
-                                        "If it cannot be expressed that way, create the reminder without a time."
-                            )
-                        ),
-                        SemanticResult.GenericFailure(
-                            "Failed to parse time",
-                            llmRecoverable = true
-                        )
-                    )
-                }
-            }.toInstant(tz)
+        logger.i {
+            "create_reminder message=${remindArgs.message} date_time_human=${remindArgs.date_time_human} duration_human=${remindArgs.duration_human}"
         }
 
-        // Lead time only makes sense alongside a reminder time; ignore otherwise.
+        val instant = resolveDeadline(remindArgs, context)
+        logger.i { "create_reminder resolved deadline=${instant?.toString()} epochMs=${instant?.toEpochMilliseconds()}" }
+
         val notifyBefore = instant?.let {
             remindArgs.notification_hours_before?.takeIf { hours -> hours > 0 }?.hours
         }
@@ -228,13 +122,69 @@ class ReminderTool: BuiltInMcpTool(
             logger.e(e) { "Failed to create reminder" }
             ToolCallResult(
                 JsonSnake.encodeToString(
-                    RemindResult(
-                        success = false,
-                        errorMessage = e.message
-                    )
+                    RemindResult(success = false, errorMessage = e.message)
                 ),
-                SemanticResult.GenericFailure("Failed to create reminder: ${e.message}")
+                SemanticResult.GenericFailure(
+                    "Failed to create reminder",
+                    llmRecoverable = true
+                )
             )
         }
+    }
+
+    /**
+     * Prefer the dedicated time fields, then fall back to parsing the message itself
+     * so "Remind me to call mom at five p.m." still gets a 5pm Once reminder when
+     * the model stuffed the time into `message` and left `date_time_human` empty.
+     */
+    private fun resolveDeadline(args: RemindArgs, context: SessionContext): Instant? {
+        val candidates = listOfNotNull(
+            args.date_time_human?.takeIf { it.isNotBlank() },
+            args.duration_human?.takeIf { it.isNotBlank() },
+            args.message.takeIf { it.isNotBlank() },
+        )
+        for (candidate in candidates) {
+            parseHumanDateTime(candidate, context)?.let { return it }
+        }
+        return null
+    }
+
+    private fun parseHumanDateTime(dateTimeHuman: String, context: SessionContext): Instant? {
+        val tz = TimeZone.currentSystemDefault()
+        val timeBase = context.timeBase
+        val anchor = timeBase ?: Clock.System.now()
+        val parser = HumanDateTimeParser(clock = anchor.asFrozenClock(), timeZone = tz)
+        val parsed = parser.parse(dateTimeHuman) ?: return null
+        if (timeBase == null && parsed is InterpretedDateTime.Relative) return null
+        val local = when (parsed) {
+            is InterpretedDateTime.AbsoluteDate -> {
+                LocalDateTime(date = parsed.date, time = LocalTime(9, 0))
+            }
+            is InterpretedDateTime.AbsoluteDateTime -> parsed.dateTime
+            is InterpretedDateTime.AbsoluteTime -> {
+                val currentTime = anchor.toLocalDateTime(tz)
+                if (parsed.time < currentTime.time) {
+                    LocalDateTime(
+                        date = currentTime.date.plus(DatePeriod(days = 1)),
+                        time = parsed.time
+                    )
+                } else {
+                    LocalDateTime(date = currentTime.date, time = parsed.time)
+                }
+            }
+            is InterpretedDateTime.Relative -> {
+                val currentTime = anchor
+                val period = parsed.period
+                if (period != null) {
+                    val localNow = currentTime.toLocalDateTime(tz)
+                    val newDate = localNow.date.plus(period)
+                    (LocalDateTime(newDate, localNow.time).toInstant(tz) + parsed.duration)
+                        .toLocalDateTime(tz)
+                } else {
+                    (currentTime + parsed.duration).toLocalDateTime(tz)
+                }
+            }
+        }
+        return local.toInstant(tz)
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/INDEX_LOCAL_CAPTURE.md
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/INDEX_LOCAL_CAPTURE.md
@@ -1,0 +1,103 @@
+# Index Local Capture API
+
+Send Index 01 recordings to another app on the same Android phone using an
+**explicit intent**. No internet, no webhook, no `INTERNET` permission on the
+receiver. Audio and transcription travel through a `FileProvider` content URI
+and string extras.
+
+This is the local counterpart of the Index Webhook API. The webhook still
+exists. Notesnook is a Notes destination (like Notion, Obsidian, and Tasker),
+not a separate sidecar.
+
+## Why not ACTION_SEND?
+
+`ACTION_SEND` / share-sheet delivery:
+
+- Requires an Activity, so Android's background-activity-launch rules drop it
+  when the screen is locked or Pebble is a connected-device foreground service.
+- Cannot grant a content URI to a specific package without a chooser.
+- Notesnook's share extension is a UI (`ShareActivity`) — the user would have
+  to tap Save on every capture.
+
+Local capture instead uses `startForegroundService` + an explicit component
+name, which a connected-device FGS (Pebble) is allowed to start, and a
+manifest-registered receiver as fallback.
+
+## Setup (Pebble Core)
+
+1. Index 01 Settings → **Add integration** → **Notesnook** → Connect
+   (or Notes → **Where notes save** → Notesnook)
+2. Hold & Talk (and other Index-agent recordings) deliver audio + transcription
+   to Notesnook on this phone
+
+The send happens when Notesnook is the selected notes destination. Webhook
+delivery is independent. A gesture routed to **Nothing** or **Web search**
+does not send.
+
+If you previously used **Local apps → Notesnook**, that toggle is migrated:
+Notesnook becomes the selected notes destination automatically.
+
+## Setup (Notesnook)
+
+1. Settings → **Productivity** → **Pebble Index 01**
+2. Leave **Receive Index captures** on (default)
+3. Optionally enable **Keep ready in background** — a long-lived foreground
+   service so Headless JS is already warm when a capture arrives (and so
+   Android is less likely to kill the process between captures)
+
+## Intent contract
+
+```
+startForegroundService
+  Component: com.streetwriters.notesnook / com.streetwriters.notesnook.pebble.PebbleIndexCaptureService
+  Action:    com.streetwriters.notesnook.action.INDEX_CAPTURE
+  Type:      audio/mp4   (when audio is present)
+             text/plain  (transcription-only)
+  Flags:     FLAG_GRANT_READ_URI_PERMISSION
+  ClipData:  content URI of the M4A (when audio is present)
+```
+
+Fallback if the service cannot be started: the same extras are broadcast to
+
+```
+com.streetwriters.notesnook.pebble.PebbleIndexCaptureReceiver
+```
+
+The receiver immediately starts the service.
+
+The service is exported but permission-gated:
+
+```
+com.streetwriters.notesnook.permission.RECEIVE_INDEX_CAPTURE
+```
+
+Pebble holds that permission. The service also rejects callers whose UID is
+not `coredevices.coreapp` (or Notesnook itself, for the receiver hop).
+
+### Extras
+
+| Extra | Type | When |
+|---|---|---|
+| `transcription` | String | Transcription / Both, and STT succeeded |
+| `recordedAt` | long | Always. Unix epoch milliseconds |
+| `client` | String | Always. `"ring"` |
+| `recordingId` | String | Always. Same id used for the M4A filename |
+| `trigger` | String | Always. `single-click-hold`, `double-click-hold`, or `test-event` |
+| `payloadMode` | String | Always. `recording`, `transcription`, or `both` |
+| `audioSize` | int | Audio is present. Byte count of the M4A |
+| `test` | boolean | Test events only |
+| `android.intent.extra.STREAM` | Uri | Audio is present. `content://coredevices.coreapp.fileprovider/index_local/<id>.m4a` |
+
+Audio format matches the webhook: AAC-LC in M4A, mono, 16 kHz.
+
+## Package visibility
+
+Pebble declares:
+
+```xml
+<queries>
+  <package android:name="com.streetwriters.notesnook" />
+</queries>
+```
+
+so `PackageManager` can see Notesnook on Android 11+.

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalAppPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalAppPreferences.kt
@@ -1,0 +1,80 @@
+package coredevices.ring.external.indexlocal
+
+import com.russhwolf.settings.Settings
+import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
+import coredevices.ring.service.button.GestureDestination
+import coredevices.ring.service.button.GestureKind
+import coredevices.ring.service.button.RingGesture
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Per-gesture config for on-device app delivery (Notesnook, etc.). */
+@Serializable
+data class IndexLocalAppConfig(
+    val notesnookEnabled: Boolean = false,
+    val payloadMode: IndexWebhookPayloadMode = IndexWebhookPayloadMode.Both,
+) {
+    val isActive: Boolean get() = notesnookEnabled
+}
+
+/**
+ * A recording gesture sends to local apps when the config is active and the
+ * gesture is not routed to [GestureDestination.Nothing].
+ */
+fun IndexLocalAppConfig.sendsFor(destination: GestureDestination.Recording): Boolean =
+    isActive && destination != GestureDestination.Nothing
+
+/**
+ * Stores one [IndexLocalAppConfig] per recording gesture. Local capture is a
+ * sidecar (like the webhook), not a gesture destination of its own.
+ */
+class IndexLocalAppPreferences(private val settings: Settings) {
+
+    companion object {
+        private const val CONFIG_KEY_PREFIX = "index_local_app_config_"
+        val gestures = RingGesture.entries.filter { it.kind == GestureKind.Recording }
+        private val json = Json { ignoreUnknownKeys = true }
+    }
+
+    private val _configs = MutableStateFlow(load())
+    val configs = _configs.asStateFlow()
+
+    fun configFor(gesture: RingGesture): IndexLocalAppConfig =
+        _configs.value[gesture] ?: IndexLocalAppConfig()
+
+    fun setConfig(gesture: RingGesture, config: IndexLocalAppConfig) {
+        settings.putString(configKey(gesture), json.encodeToString(config))
+        _configs.value = _configs.value + (gesture to config)
+    }
+
+    fun setNotesnookEnabled(gesture: RingGesture, enabled: Boolean) {
+        setConfig(gesture, configFor(gesture).copy(notesnookEnabled = enabled))
+    }
+
+    fun setPayloadMode(gesture: RingGesture, mode: IndexWebhookPayloadMode) {
+        setConfig(gesture, configFor(gesture).copy(payloadMode = mode))
+    }
+
+    fun anyEnabled(): Boolean = _configs.value.values.any { it.isActive }
+
+    fun setPayloadModeForAll(mode: IndexWebhookPayloadMode) {
+        gestures.forEach { setPayloadMode(it, mode) }
+    }
+
+    private fun configKey(gesture: RingGesture) = CONFIG_KEY_PREFIX + gesture.name
+
+    private fun load(): Map<RingGesture, IndexLocalAppConfig> =
+        gestures.associateWith { gesture ->
+            settings.getStringOrNull(configKey(gesture))
+                ?.let {
+                    try {
+                        json.decodeFromString<IndexLocalAppConfig>(it)
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+                ?: IndexLocalAppConfig()
+        }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureApi.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureApi.kt
@@ -1,0 +1,64 @@
+package coredevices.ring.external.indexlocal
+
+import coredevices.ring.audio.M4aEncoder
+import coredevices.ring.service.RecordingBackgroundScope
+import coredevices.ring.service.button.RingGesture
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+interface IndexLocalCaptureApi {
+    /**
+     * Deliver recording audio + transcription to Notesnook on this phone.
+     * No-op when Notesnook is not installed. Android-only.
+     *
+     * If [beginRecordingCapture] is active and a reminder was stashed, this
+     * sends one combined capture (audio + reminder) so Notesnook creates a
+     * single note.
+     */
+    fun deliverIfEnabled(
+        samples: ShortArray?,
+        sampleRate: Int,
+        recordingId: String,
+        transcription: String?,
+        recordedAt: Instant,
+        gesture: RingGesture,
+    )
+
+    /**
+     * Deliver an Index reminder as a Notesnook note with a reminder alarm.
+     * [deadline] is the absolute due instant (UTC). Null means no due date
+     * (Notesnook permanent reminder).
+     *
+     * While a recording capture is in progress this only stashes the reminder
+     * so [deliverIfEnabled] can send audio + reminder together.
+     */
+    fun deliverReminder(
+        title: String,
+        deadline: Instant?,
+        notifyBefore: Duration?,
+        recordingId: String,
+        recordedAt: Instant,
+    )
+
+    /** True while the recording decorator is running the Index agent. */
+    fun isCapturingRecording(): Boolean
+
+    fun beginRecordingCapture()
+
+    fun endRecordingCapture()
+
+    fun isNotesnookInstalled(): Boolean
+}
+
+data class IndexLocalCaptureRunResult(
+    val ok: Boolean,
+    val status: String,
+    val detail: String,
+    val byteSize: Long,
+    val durationMs: Long,
+)
+
+expect class IndexLocalCaptureApiImpl(
+    m4aEncoder: M4aEncoder,
+    scope: RecordingBackgroundScope,
+) : IndexLocalCaptureApi

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureContract.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureContract.kt
@@ -1,0 +1,64 @@
+package coredevices.ring.external.indexlocal
+
+import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
+import coredevices.ring.service.button.RingGesture
+
+/**
+ * Shared names for the on-device Index → Notesnook intent. Keep these in lockstep
+ * with Notesnook's `PebbleIndexContract`. They are the public ABI: do not rename.
+ */
+object IndexLocalCaptureContract {
+    const val NOTESNOOK_PACKAGE = "com.streetwriters.notesnook"
+    const val SERVICE_CLASS = "com.streetwriters.notesnook.pebble.PebbleIndexCaptureService"
+    const val RECEIVER_CLASS = "com.streetwriters.notesnook.pebble.PebbleIndexCaptureReceiver"
+    const val ACTIVITY_CLASS = "com.streetwriters.notesnook.pebble.PebbleIndexCaptureActivity"
+
+    const val ACTION = "com.streetwriters.notesnook.action.INDEX_CAPTURE"
+    const val RECEIVE_PERMISSION = "com.streetwriters.notesnook.permission.RECEIVE_INDEX_CAPTURE"
+
+    const val FILE_PROVIDER_AUTHORITY = "coredevices.coreapp.fileprovider"
+    const val CACHE_SUBDIR = "index-local"
+
+    const val EXTRA_TRANSCRIPTION = "transcription"
+    const val EXTRA_RECORDED_AT = "recordedAt"
+    const val EXTRA_CLIENT = "client"
+    const val EXTRA_RECORDING_ID = "recordingId"
+    const val EXTRA_TRIGGER = "trigger"
+    const val EXTRA_PAYLOAD_MODE = "payloadMode"
+    const val EXTRA_AUDIO_SIZE = "audioSize"
+    const val EXTRA_AUDIO_URI = "audioUri"
+    const val EXTRA_AUDIO_BASE64 = "audioBase64"
+    const val EXTRA_TEST = "test"
+    const val EXTRA_KIND = "kind"
+    const val EXTRA_TITLE = "title"
+    const val EXTRA_HAS_DEADLINE = "hasDeadline"
+    const val EXTRA_DEADLINE_EPOCH_MS = "deadlineEpochMs"
+    const val EXTRA_DEADLINE_ISO = "deadlineIso"
+    const val EXTRA_NOTIFY_BEFORE_SECONDS = "notifyBeforeSeconds"
+
+    const val CLIENT_RING = "ring"
+
+    const val KIND_NOTE = "note"
+    const val KIND_REMINDER = "reminder"
+
+    const val TRIGGER_SINGLE = "single-click-hold"
+    const val TRIGGER_DOUBLE = "double-click-hold"
+    const val TRIGGER_TEST = "test-event"
+
+    const val MODE_RECORDING = "recording"
+    const val MODE_TRANSCRIPTION = "transcription"
+    const val MODE_BOTH = "both"
+
+    const val TEST_TRANSCRIPTION = "Index local-capture test event"
+}
+
+fun RingGesture.localCaptureTriggerValue(): String = when (this) {
+    RingGesture.ClickHold -> IndexLocalCaptureContract.TRIGGER_DOUBLE
+    else -> IndexLocalCaptureContract.TRIGGER_SINGLE
+}
+
+fun IndexWebhookPayloadMode.wireName(): String = when (this) {
+    IndexWebhookPayloadMode.RecordingOnly -> IndexLocalCaptureContract.MODE_RECORDING
+    IndexWebhookPayloadMode.TranscriptionOnly -> IndexLocalCaptureContract.MODE_TRANSCRIPTION
+    IndexWebhookPayloadMode.Both -> IndexLocalCaptureContract.MODE_BOTH
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureRecordingOperation.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureRecordingOperation.kt
@@ -1,0 +1,84 @@
+package coredevices.ring.external.indexlocal
+
+import co.touchlab.kermit.Logger
+import coredevices.indexai.database.dao.LocalRecordingDao
+import coredevices.indexai.database.dao.RecordingEntryDao
+import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
+import coredevices.ring.service.button.RingGesture
+import coredevices.ring.service.recordings.RecordingProcessingQueue
+import coredevices.ring.service.recordings.button.RecordingOperation
+import coredevices.ring.storage.RecordingStorage
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.buffered
+import kotlinx.io.readShortLe
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import kotlin.time.Clock
+
+/**
+ * Decorator that delivers recording data to a local Android app (Notesnook)
+ * after the inner operation (transcription + agent) completes.
+ *
+ * Mirrors [coredevices.ring.service.recordings.button.IndexWebhookUploadRecordingOperation]
+ * but uses an explicit intent instead of HTTP.
+ */
+class IndexLocalCaptureRecordingOperation(
+    private val localCaptureApi: IndexLocalCaptureApi,
+    private val recordingStorage: RecordingStorage,
+    private val decorated: RecordingOperation,
+    private val fileId: String?,
+    private val recordingId: Long,
+    private val gesture: RingGesture,
+) : RecordingOperation, KoinComponent {
+
+    companion object {
+        private val logger = Logger.withTag("IndexLocalCaptureRecordingOperation")
+        private val sentRecordingIds = mutableSetOf<String>()
+        private val sentRecordingIdsLock = Mutex()
+    }
+
+    private val recordingEntryDao: RecordingEntryDao by inject()
+    private val localRecordingDao: LocalRecordingDao by inject()
+
+    override suspend fun run(handle: RecordingProcessingQueue.TaskHandle?) {
+        localCaptureApi.beginRecordingCapture()
+        try {
+            decorated.run(handle)
+
+            val rec = localRecordingDao.getRecording(recordingId)
+            val sendKey = rec?.firestoreId ?: fileId ?: "text-$recordingId"
+            val payloadMode = IndexWebhookPayloadMode.Both
+            if (!sentRecordingIdsLock.withLock { sentRecordingIds.add(sendKey) }) {
+                logger.d { "Local capture already sent for recording $sendKey, skipping" }
+                return
+            }
+
+            val samples: ShortArray?
+            val sampleRate: Int
+            if (fileId != null && payloadMode != IndexWebhookPayloadMode.TranscriptionOnly) {
+                val (source, meta) = recordingStorage.openRecordingSource(fileId)
+                samples = ShortArray((meta.size / 2).toInt())
+                source.buffered().use {
+                    for (i in samples.indices) {
+                        samples[i] = it.readShortLe()
+                    }
+                }
+                sampleRate = meta.cachedMetadata.sampleRate
+            } else {
+                samples = null
+                sampleRate = 16000
+            }
+
+            val transcription: String? = if (payloadMode != IndexWebhookPayloadMode.RecordingOnly) {
+                recordingEntryDao.getMostRecentEntryForRecording(recordingId)?.transcription
+            } else null
+
+            val recordedAt = rec?.localTimestamp ?: Clock.System.now()
+
+            localCaptureApi.deliverIfEnabled(samples, sampleRate, sendKey, transcription, recordedAt, gesture)
+        } finally {
+            localCaptureApi.endRecordingCapture()
+        }
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperationFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/RecordingOperationFactory.kt
@@ -6,11 +6,16 @@ import coredevices.mcp.data.ToolCallResult
 import coredevices.ring.agent.AgentFactory
 import coredevices.ring.agent.ChatMode
 import coredevices.ring.agent.McpSessionFactory
+import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
+import coredevices.ring.agent.builtin_servlets.reminders.ReminderProvider
+import coredevices.ring.database.Preferences
 import coredevices.ring.database.room.repository.ItemRepository
 import coredevices.ring.database.room.repository.McpSandboxRepository
+import coredevices.ring.external.indexlocal.IndexLocalCaptureApi
+import coredevices.ring.external.indexlocal.IndexLocalCaptureRecordingOperation
 import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
-import coredevices.ring.external.indexwebhook.sendsFor
+import coredevices.ring.external.indexwebhook.sendsFor as webhookSendsFor
 import coredevices.ring.service.ButtonPress
 import coredevices.indexai.data.entity.mcp_sandbox.McpSandboxGroupEntity
 import coredevices.ring.service.button.GestureDestination
@@ -28,10 +33,12 @@ class RecordingOperationFactory(
     private val gestureRouting: GestureRoutingPreferences,
     private val indexWebhookApi: IndexWebhookApi,
     private val indexWebhookPreferences: IndexWebhookPreferences,
+    private val indexLocalCaptureApi: IndexLocalCaptureApi,
     private val recordingStorage: RecordingStorage,
     private val trace: RingTraceSession,
     private val itemFactory: ItemFactory,
     private val itemRepository: ItemRepository,
+    private val preferences: Preferences,
 ) {
     suspend fun createForButtonSequence(
         recordingId: Long,
@@ -42,22 +49,35 @@ class RecordingOperationFactory(
     ): RecordingOperation {
         val gesture = sequence?.let { RingGesture.forSequence(it) }
         val destination = gestureRouting.recordingDestinationFor(gesture)
+        val notesnookNotes = preferences.noteProvider.value == NoteProvider.Notesnook
         val inner = createForDestination(
             destination = destination,
             recordingId = recordingId,
             fileId = fileId,
             transferId = transferId,
-            forcedTool = forcedNoteTool
+            // The local-capture decorator owns the Notesnook note (audio + transcript).
+            // Skip CreateNoteTool so the same hold does not create a second text-only note.
+            forcedTool = if (notesnookNotes && destination == GestureDestination.IndexAgent) {
+                { text, _ -> notesnookCaptureResult(text) }
+            } else {
+                forcedNoteTool
+            }
         )
         // The phone's own hold-to-record has no gesture and borrows Hold & Talk's webhook, so the
         // send is gated on Hold & Talk's route too — not the agent route resolved above.
         val webhookGesture = gesture ?: RingGesture.Hold
-        return maybeWrapWithWebhook(
+        return maybeWrapWithLocalCapture(
             recordingId = recordingId,
             fileId = fileId,
             gesture = webhookGesture,
             destination = gestureRouting.recordingDestinationFor(webhookGesture),
-            inner = inner,
+            inner = maybeWrapWithWebhook(
+                recordingId = recordingId,
+                fileId = fileId,
+                gesture = webhookGesture,
+                destination = gestureRouting.recordingDestinationFor(webhookGesture),
+                inner = inner,
+            ),
         )
     }
 
@@ -68,10 +88,31 @@ class RecordingOperationFactory(
         destination: GestureDestination.Recording,
         inner: RecordingOperation,
     ): RecordingOperation {
-        if (!indexWebhookPreferences.configFor(gesture).sendsFor(destination)) return inner
+        if (!indexWebhookPreferences.configFor(gesture).webhookSendsFor(destination)) return inner
         return IndexWebhookUploadRecordingOperation(
             webhookApi = indexWebhookApi,
             webhookPreferences = indexWebhookPreferences,
+            recordingStorage = recordingStorage,
+            fileId = fileId,
+            recordingId = recordingId,
+            gesture = gesture,
+            decorated = inner,
+        )
+    }
+
+    private fun maybeWrapWithLocalCapture(
+        recordingId: Long,
+        fileId: String?,
+        gesture: RingGesture,
+        destination: GestureDestination.Recording,
+        inner: RecordingOperation,
+    ): RecordingOperation {
+        if (destination != GestureDestination.IndexAgent) return inner
+        val notesnookNotes = preferences.noteProvider.value == NoteProvider.Notesnook
+        val notesnookReminders = preferences.reminderProvider.value == ReminderProvider.Notesnook
+        if (!notesnookNotes && !notesnookReminders) return inner
+        return IndexLocalCaptureRecordingOperation(
+            localCaptureApi = indexLocalCaptureApi,
             recordingStorage = recordingStorage,
             fileId = fileId,
             recordingId = recordingId,
@@ -89,6 +130,7 @@ class RecordingOperationFactory(
         // A typed question routes to the search/answer agent and forces no note. Anything else
         // follows wherever Hold & Talk points, so typing stands in for the gesture.
         val destination = gestureRouting.recordingDestinationFor(RingGesture.Hold)
+        val notesnookNotes = preferences.noteProvider.value == NoteProvider.Notesnook
         val mode = if (isQuestion) {
             ChatMode.Search
         } else {
@@ -101,14 +143,26 @@ class RecordingOperationFactory(
             recordingId = recordingId,
             chatAgent = agent,
             text = text,
-            forcedTool = if (isQuestion) null else forcedTool,
+            forcedTool = if (isQuestion) {
+                null
+            } else if (notesnookNotes && destination == GestureDestination.IndexAgent) {
+                { _ -> notesnookCaptureResult(text) }
+            } else {
+                forcedTool
+            },
         )
-        return maybeWrapWithWebhook(
+        return maybeWrapWithLocalCapture(
             recordingId = recordingId,
             fileId = null,
             gesture = RingGesture.Hold,
             destination = destination,
-            inner = inner,
+            inner = maybeWrapWithWebhook(
+                recordingId = recordingId,
+                fileId = null,
+                gesture = RingGesture.Hold,
+                destination = destination,
+                inner = inner,
+            ),
         )
     }
 
@@ -192,6 +246,12 @@ class RecordingOperationFactory(
             semanticResult = SemanticResult.Response(answer, question = question)
         )
     }
+
+    private fun notesnookCaptureResult(text: String): ToolCallResult =
+        ToolCallResult(
+            resultString = "",
+            semanticResult = SemanticResult.ListItemCreation(text)
+        )
 }
 
 private object NoAgentRecordingOperation : RecordingOperation {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
@@ -45,7 +45,9 @@ import co.touchlab.kermit.Logger
 import coreapp.util.generated.resources.back
 import coredevices.ring.agent.builtin_servlets.notes.NoteIntegrationFactory
 import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
+import coredevices.ring.agent.builtin_servlets.notes.NOTESNOOK_DEFINITION
 import coredevices.ring.agent.builtin_servlets.notes.TASKER_DEFINITION
+import coredevices.ring.agent.builtin_servlets.reminders.ReminderProvider
 import coredevices.ring.agent.integrations.GTasksIntegration
 import coredevices.ring.agent.integrations.NotionIntegration
 import coredevices.ring.agent.integrations.obsidian.ObsidianIntegration
@@ -53,6 +55,7 @@ import coredevices.ring.agent.integrations.obsidian.ObsidianMode
 import coredevices.ring.agent.integrations.obsidian.ObsidianPreferences
 import coredevices.ring.data.IntegrationDefinition
 import coredevices.ring.database.Preferences
+import coredevices.ring.external.indexlocal.IndexLocalCaptureApi
 import coredevices.ui.M3Dialog
 import coredevices.util.Permission
 import coredevices.util.PermissionRequester
@@ -148,6 +151,16 @@ fun AddIntegration(coreNav: CoreNav) {
                     Item(def) {
                         dialog = {
                             TaskerDialog(
+                                onDismiss = { dialog = null }
+                            )
+                        }
+                    }
+                }
+                item {
+                    val def = remember { NOTESNOOK_DEFINITION }
+                    Item(def) {
+                        dialog = {
+                            NotesnookDialog(
                                 onDismiss = { dialog = null }
                             )
                         }
@@ -748,6 +761,127 @@ fun TaskerDialog(
             }
             is SignInState.Success -> {
                 Text("Tasker connected. Choose it for notes or reminders in Index settings.")
+            }
+            is SignInState.Error -> {
+                Text(
+                    "Error: ${s.message}",
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun NotesnookConfigDialog(
+    onDismiss: () -> Unit
+) {
+    val noteIntegrationFactory = koinInject<NoteIntegrationFactory>()
+    val preferences = koinInject<Preferences>()
+    val scope = rememberCoroutineScope()
+
+    M3Dialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Notesnook") },
+        buttons = {
+            TextButton(
+                onClick = {
+                    scope.launch {
+                        noteIntegrationFactory.createNoteClient(NoteProvider.Notesnook).unlink()
+                        if (preferences.noteProvider.value == NoteProvider.Notesnook) {
+                            preferences.setNoteProvider(NoteProvider.Builtin)
+                        }
+                        if (preferences.reminderProvider.value == ReminderProvider.Notesnook) {
+                            preferences.setReminderProvider(ReminderProvider.BuiltIn)
+                        }
+                        onDismiss()
+                    }
+                }
+            ) { Text("Disconnect") }
+            TextButton(onClick = onDismiss) { Text("Close") }
+        }
+    ) {
+        Text(
+            "Index notes and reminders go to Notesnook on this phone. Audio, transcription, " +
+                "and reminder due times are sent with an explicit intent — no internet."
+        )
+    }
+}
+
+@Composable
+fun NotesnookDialog(
+    onDismiss: () -> Unit
+) {
+    val uiContext = rememberUiContext()!!
+    val noteIntegrationFactory = koinInject<NoteIntegrationFactory>()
+    val preferences = koinInject<Preferences>()
+    val api = koinInject<IndexLocalCaptureApi>()
+    var state by remember { mutableStateOf<SignInState>(SignInState.Idle) }
+    val installed = remember { api.isNotesnookInstalled() }
+    val scope = rememberCoroutineScope()
+
+    M3Dialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Notesnook") },
+        buttons = {
+            TextButton(onClick = onDismiss) {
+                Text(if (state is SignInState.Success) "Done" else "Cancel")
+            }
+            if (state !is SignInState.Success) {
+                Spacer(Modifier.width(8.dp))
+                TextButton(
+                    enabled = state !is SignInState.SigningIn && installed,
+                    onClick = {
+                        state = SignInState.SigningIn
+                        scope.launch {
+                            state = try {
+                                val client = noteIntegrationFactory.createNoteClient(NoteProvider.Notesnook)
+                                if (client.signIn(uiContext)) {
+                                    preferences.setNoteProvider(NoteProvider.Notesnook)
+                                    SignInState.Success
+                                } else {
+                                    SignInState.Error("Notesnook is not installed. Install it, then try again.")
+                                }
+                            } catch (e: Throwable) {
+                                Logger.w("AddIntegration", e) { "Error connecting Notesnook: ${e.message}" }
+                                SignInState.Error(e.message ?: "Unknown error")
+                            }
+                        }
+                    }
+                ) {
+                    Text("Connect")
+                }
+            }
+        }
+    ) {
+        when (val s = state) {
+            is SignInState.Idle -> {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        "Saves Index notes and reminders to Notesnook on this phone. " +
+                            "Audio, transcription, and reminder due times are sent with an " +
+                            "explicit intent — no internet."
+                    )
+                    if (!installed) {
+                        Text(
+                            "Notesnook is not installed. Install it, then come back to connect.",
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
+            is SignInState.SigningIn -> {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            is SignInState.Success -> {
+                Text("Notesnook connected. Choose it for notes or reminders in Index settings.")
             }
             is SignInState.Error -> {
                 Text(

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexActionsSection.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexActionsSection.kt
@@ -115,7 +115,12 @@ internal fun noteDestOptions(
     available: List<NoteProvider>,
     isAndroid: Boolean,
 ): List<DestOption<NoteProvider>> = NoteProvider.entries
-    .filter { it != NoteProvider.Tasker || isAndroid }
+    .filter {
+        when (it) {
+            NoteProvider.Tasker, NoteProvider.Notesnook -> isAndroid
+            else -> true
+        }
+    }
     .map { DestOption(it, it.settingsTitle, it in available) }
 
 internal fun reminderDestOptions(
@@ -124,7 +129,7 @@ internal fun reminderDestOptions(
 ): List<DestOption<ReminderProvider>> = ReminderProvider.entries
     .filter {
         when (it) {
-            ReminderProvider.Tasker -> isAndroid
+            ReminderProvider.Tasker, ReminderProvider.Notesnook -> isAndroid
             ReminderProvider.IOSReminders -> !isAndroid
             else -> true
         }
@@ -141,12 +146,14 @@ internal fun noteConnectDialog(provider: NoteProvider): ActionsDialog? = when (p
     NoteProvider.Notion -> ActionsDialog.Notion
     NoteProvider.Obsidian -> ActionsDialog.Obsidian
     NoteProvider.Tasker -> ActionsDialog.Tasker
+    NoteProvider.Notesnook -> ActionsDialog.Notesnook
     NoteProvider.Builtin -> null
 }
 
 internal fun reminderConnectDialog(provider: ReminderProvider): ActionsDialog? = when (provider) {
     ReminderProvider.GoogleTasks -> ActionsDialog.GoogleTasks
     ReminderProvider.Tasker -> ActionsDialog.Tasker
+    ReminderProvider.Notesnook -> ActionsDialog.Notesnook
     ReminderProvider.BuiltIn, ReminderProvider.IOSReminders -> null
 }
 
@@ -182,7 +189,7 @@ private fun presentationFor(action: IndexAction): ActionPresentation = when (act
 }
 
 private enum class ActionsSheet { CaptureType, NoteDestination, ReminderDestination }
-internal enum class ActionsDialog { AddServer, Sideload, Notion, GoogleTasks, Obsidian, Tasker, PhoneCalendar }
+internal enum class ActionsDialog { AddServer, Sideload, Notion, GoogleTasks, Obsidian, Tasker, Notesnook, PhoneCalendar }
 
 @Composable
 fun IndexActionsSection(
@@ -369,6 +376,7 @@ fun IndexActionsSection(
         ActionsDialog.GoogleTasks -> GTasksDialog(onDismiss = closeConnectDialog)
         ActionsDialog.Obsidian -> ObsidianDialog(onDismiss = closeConnectDialog)
         ActionsDialog.Tasker -> TaskerDialog(onDismiss = closeConnectDialog)
+        ActionsDialog.Notesnook -> NotesnookDialog(onDismiss = closeConnectDialog)
         ActionsDialog.PhoneCalendar -> PhoneCalendarDialog(onDismiss = { dialog = null })
         null -> {}
     }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexSettings.kt
@@ -88,6 +88,7 @@ import co.touchlab.kermit.Logger
 import coreapp.util.generated.resources.back
 import coreapp.util.generated.resources.settings
 import coredevices.ring.agent.LlmMode
+import coredevices.ring.agent.builtin_servlets.notes.NOTESNOOK_DEFINITION
 import coredevices.ring.agent.builtin_servlets.notes.NoteIntegrationFactory
 import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
 import coredevices.ring.agent.builtin_servlets.notes.TASKER_DEFINITION
@@ -1410,6 +1411,9 @@ fun AuthorizedIntegrations(preferences: Preferences) {
     val taskerAuth by flow {
         emit(noteIntegrationFactory.createNoteClient(NoteProvider.Tasker).isAuthorized())
     }.collectAsState(false)
+    val notesnookAuth by flow {
+        emit(noteIntegrationFactory.createNoteClient(NoteProvider.Notesnook).isAuthorized())
+    }.collectAsState(false)
     val currentReminderProvider by preferences.reminderProvider.collectAsState()
     val currentNoteProvider by preferences.noteProvider.collectAsState()
 
@@ -1523,6 +1527,22 @@ fun AuthorizedIntegrations(preferences: Preferences) {
                 selectedNoteProvider = currentNoteProvider == NoteProvider.Tasker,
                 onSelectReminderProvider = { preferences.setReminderProvider(ReminderProvider.Tasker) },
                 onSelectNoteProvider = { preferences.setNoteProvider(NoteProvider.Tasker) }
+            )
+        }
+        if (platform.isAndroid && notesnookAuth) {
+            var showNotesnookConfig by remember { mutableStateOf(false) }
+            if (showNotesnookConfig) {
+                NotesnookConfigDialog(onDismiss = { showNotesnookConfig = false })
+            }
+            IntegrationItem(
+                title = NOTESNOOK_DEFINITION.title,
+                hasReminder = true,
+                hasNotes = true,
+                selectedReminderProvider = currentReminderProvider == ReminderProvider.Notesnook,
+                selectedNoteProvider = currentNoteProvider == NoteProvider.Notesnook,
+                onSelectReminderProvider = { preferences.setReminderProvider(ReminderProvider.Notesnook) },
+                onSelectNoteProvider = { preferences.setNoteProvider(NoteProvider.Notesnook) },
+                onConfigure = { showNotesnookConfig = true },
             )
         }
     }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/viewmodel/SettingsViewModel.kt
@@ -221,6 +221,11 @@ class SettingsViewModel(
             ) {
                 add(ReminderProvider.Tasker)
             }
+            if (platform.isAndroid &&
+                noteIntegrationFactory.createNoteClient(NoteProvider.Notesnook).isAuthorized()
+            ) {
+                add(ReminderProvider.Notesnook)
+            }
         }
     }
 

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexlocal/IndexLocalAppPreferencesTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexlocal/IndexLocalAppPreferencesTest.kt
@@ -1,0 +1,70 @@
+package coredevices.ring.external.indexlocal
+
+import com.russhwolf.settings.MapSettings
+import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
+import coredevices.ring.service.button.GestureDestination
+import coredevices.ring.service.button.RingGesture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IndexLocalAppPreferencesTest {
+
+    @Test
+    fun recordingGesturesAreHoldAndClickHold() {
+        assertEquals(
+            listOf(RingGesture.Hold, RingGesture.ClickHold),
+            IndexLocalAppPreferences.gestures,
+        )
+    }
+
+    @Test
+    fun defaultConfigIsInactive() {
+        val prefs = IndexLocalAppPreferences(MapSettings())
+        assertEquals(IndexLocalAppConfig(), prefs.configFor(RingGesture.Hold))
+        assertFalse(prefs.configFor(RingGesture.Hold).isActive)
+    }
+
+    @Test
+    fun enablingNotesnookPersistsPerGesture() {
+        val settings = MapSettings()
+        val prefs = IndexLocalAppPreferences(settings)
+        prefs.setConfig(
+            RingGesture.Hold,
+            IndexLocalAppConfig(
+                notesnookEnabled = true,
+                payloadMode = IndexWebhookPayloadMode.Both,
+            ),
+        )
+        val reloaded = IndexLocalAppPreferences(settings)
+        assertTrue(reloaded.configFor(RingGesture.Hold).isActive)
+        assertEquals(IndexWebhookPayloadMode.Both, reloaded.configFor(RingGesture.Hold).payloadMode)
+        assertFalse(reloaded.configFor(RingGesture.ClickHold).isActive)
+    }
+
+    @Test
+    fun anyEnabledIsTrueWhenAnyGestureIsOn() {
+        val prefs = IndexLocalAppPreferences(MapSettings())
+        assertFalse(prefs.anyEnabled())
+        prefs.setNotesnookEnabled(RingGesture.ClickHold, true)
+        assertTrue(prefs.anyEnabled())
+    }
+
+    @Test
+    fun doesNotSendWhenRoutedToNothing() {
+        val config = IndexLocalAppConfig(notesnookEnabled = true)
+        assertTrue(config.sendsFor(GestureDestination.IndexAgent))
+        assertTrue(config.sendsFor(GestureDestination.WebhookOnly))
+        assertFalse(config.sendsFor(GestureDestination.Nothing))
+    }
+
+    @Test
+    fun triggerWireNamesAreStable() {
+        assertEquals("single-click-hold", RingGesture.Hold.localCaptureTriggerValue())
+        assertEquals("double-click-hold", RingGesture.ClickHold.localCaptureTriggerValue())
+        assertEquals("both", IndexWebhookPayloadMode.Both.wireName())
+        assertEquals("recording", IndexWebhookPayloadMode.RecordingOnly.wireName())
+        assertEquals("transcription", IndexWebhookPayloadMode.TranscriptionOnly.wireName())
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/ui/screens/settings/IndexActionsSectionTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/ui/screens/settings/IndexActionsSectionTest.kt
@@ -113,10 +113,30 @@ class IndexActionsSectionTest {
     }
 
     @Test
+    fun `notesnook is only offered on android`() {
+        assertFalse(
+            noteDestOptions(emptyList(), isAndroid = false).any { it.provider == NoteProvider.Notesnook }
+        )
+        assertTrue(
+            noteDestOptions(emptyList(), isAndroid = true).any { it.provider == NoteProvider.Notesnook }
+        )
+        assertFalse(
+            reminderDestOptions(emptyList(), isAndroid = false)
+                .any { it.provider == ReminderProvider.Notesnook }
+        )
+        assertTrue(
+            reminderDestOptions(emptyList(), isAndroid = true)
+                .any { it.provider == ReminderProvider.Notesnook }
+        )
+    }
+
+    @Test
     fun `connecting a provider opens that provider's own flow`() {
         assertEquals(ActionsDialog.Notion, noteConnectDialog(NoteProvider.Notion))
         assertEquals(ActionsDialog.Obsidian, noteConnectDialog(NoteProvider.Obsidian))
         assertEquals(ActionsDialog.Tasker, noteConnectDialog(NoteProvider.Tasker))
+        assertEquals(ActionsDialog.Notesnook, noteConnectDialog(NoteProvider.Notesnook))
+        assertEquals(ActionsDialog.Notesnook, reminderConnectDialog(ReminderProvider.Notesnook))
         assertEquals(ActionsDialog.GoogleTasks, reminderConnectDialog(ReminderProvider.GoogleTasks))
         assertEquals(ActionsDialog.Tasker, reminderConnectDialog(ReminderProvider.Tasker))
     }

--- a/experimental/src/iosMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookNoteClient.ios.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NotesnookNoteClient.ios.kt
@@ -1,0 +1,16 @@
+package coredevices.ring.agent.builtin_servlets.notes
+
+import PlatformUiContext
+import coredevices.ring.agent.integrations.ItemSource
+import coredevices.ring.agent.integrations.NoteIntegration
+
+/**
+ * Notesnook capture is Android-only (explicit intents). iOS returns a disabled stub so it is
+ * filtered out of available note providers and never offered.
+ */
+actual fun createNotesnookNoteClient(): NoteIntegration = object : NoteIntegration {
+    override suspend fun createNote(content: String, source: ItemSource?): String? = null
+    override suspend fun signIn(uiContext: PlatformUiContext): Boolean = false
+    override suspend fun unlink() {}
+    override suspend fun isAuthorized(): Boolean = false
+}

--- a/experimental/src/iosMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/NotesnookReminderIntegration.ios.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/ring/agent/builtin_servlets/reminders/NotesnookReminderIntegration.ios.kt
@@ -1,0 +1,28 @@
+package coredevices.ring.agent.builtin_servlets.reminders
+
+import PlatformUiContext
+import coredevices.ring.agent.integrations.ItemSource
+import coredevices.ring.agent.integrations.ReminderIntegration
+import coredevices.ring.agent.integrations.ReminderListEntry
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+actual fun createNotesnookReminderIntegration(): ReminderIntegration =
+    DisabledNotesnookReminderIntegration()
+
+private class DisabledNotesnookReminderIntegration : ReminderIntegration {
+    override suspend fun createReminder(
+        title: String,
+        deadline: Instant?,
+        listId: String?,
+        notifyBefore: Duration?,
+        source: ItemSource?,
+    ): String = error("Notesnook is Android-only")
+
+    override suspend fun searchForList(listName: String): List<ReminderListEntry> =
+        error("Notesnook is Android-only")
+
+    override suspend fun signIn(uiContext: PlatformUiContext): Boolean = false
+    override suspend fun unlink() {}
+    override suspend fun isAuthorized(): Boolean = false
+}

--- a/experimental/src/iosMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureApi.ios.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/ring/external/indexlocal/IndexLocalCaptureApi.ios.kt
@@ -1,0 +1,36 @@
+package coredevices.ring.external.indexlocal
+
+import coredevices.ring.audio.M4aEncoder
+import coredevices.ring.service.RecordingBackgroundScope
+import coredevices.ring.service.button.RingGesture
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+actual class IndexLocalCaptureApiImpl actual constructor(
+    m4aEncoder: M4aEncoder,
+    scope: RecordingBackgroundScope,
+) : IndexLocalCaptureApi {
+
+    override fun isNotesnookInstalled(): Boolean = false
+
+    override fun isCapturingRecording(): Boolean = false
+    override fun beginRecordingCapture() = Unit
+    override fun endRecordingCapture() = Unit
+
+    override fun deliverIfEnabled(
+        samples: ShortArray?,
+        sampleRate: Int,
+        recordingId: String,
+        transcription: String?,
+        recordedAt: Instant,
+        gesture: RingGesture,
+    ) = Unit
+
+    override fun deliverReminder(
+        title: String,
+        deadline: Instant?,
+        notifyBefore: Duration?,
+        recordingId: String,
+        recordedAt: Instant,
+    ) = Unit
+}


### PR DESCRIPTION
## Description

Used Grok to make a portion of this code.

Add **Notesnook** as a first-class Index destination for notes and reminders, delivered on-device over an explicit Android intent. No webhook and no internet on the capture path.

Notesnook sits next to Notion, Obsidian, and Tasker. Choosing Notesnook as the notes and/or reminders provider sends Hold & Talk recordings to Notesnook on the same phone: M4A via `FileProvider`, transcription and reminder metadata as extras (`kind`, title, `hasDeadline`, `deadlineEpochMs`, `deadlineIso`).

One recording becomes one Notesnook note:
- The recording decorator always delivers audio + transcription when Notesnook is the notes or reminders provider.
- Agent `createNote` is a no-op while a recording is in flight (avoids a second empty note).
- Agent reminders are stashed and merged into that same capture (`kind=reminder`) instead of being sent as a second intent.
- `ReminderTool` falls back to `HumanDateTimeParser` on the utterance when the model omits `date_time_human`, so “remind me to call mom at five p.m.” gets a timed `once` deadline instead of a permanent alert.

Connect/configure dialogs live in Add integration / Index actions, same pattern as the other destinations. iOS clients are stubs (local capture is Android-only).

Also includes a skip-signin control on first launch so the app can be used without an account when only local destinations are needed.

The PR for the android Notesnook app is here: https://github.com/streetwriters/notesnook/pull/10273

## Type of change
- [x] Feature
- [x] Bug fix

## Testing
- Unit: `IndexLocalAppPreferencesTest`, `IndexActionsSectionTest`
- Existing recording queue / E2E tests updated for the Notesnook provider
- On-device with Notesnook: single note per capture (audio + transcription), reminder merged onto that note with correct deadline, no duplicate notes

Hardware-dependent intent delivery is not fully covered by CI.

## Platform
- Android (Index local capture)
- iOS: no-op clients so the shared note/reminder provider enums compile