### PR TITLE
ci: update softprops/action-gh-release to v3.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Add release artifacts
         id: release_artifacts
-        uses: softprops/action-gh-release@15d2aaca23625e5b2744248f7b68fc1e6bbff48e
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: |


### PR DESCRIPTION
Saw in https://github.com/coredevices/mobileapp/pull/363 that Depenabot was bumping this from one random commit from ~v0.1.15 to the latest on the default branch rather than an actual release.
This just points to the latest current release commit and adds the metadata so that Dependabot knows to look for an actual release next time.

I do note that this workflow doesn't appear to be used right now, so maybe it's better to just delete this file, unless it's being used by your internal repo.