### PR TITLE
Add Memos as a note destination

### DIFF
--- a/experimental/build.gradle.kts
+++ b/experimental/build.gradle.kts
@@ -277,6 +277,8 @@ buildkonfig {
         buildConfigField(FieldSpec.Type.STRING, "NOTION_OAUTH_BACKEND_URL", "https://index-oauth.repebble.com")
 
         buildConfigField(FieldSpec.Type.STRING, "TESTS_NOTION_TOKEN", System.getenv("TESTS_NOTION_TOKEN") ?: properties.getProperty("TESTS_NOTION_TOKEN") ?: "")
+        buildConfigField(FieldSpec.Type.STRING, "TESTS_MEMOS_URL", System.getenv("TESTS_MEMOS_URL") ?: properties.getProperty("TESTS_MEMOS_URL") ?: "")
+        buildConfigField(FieldSpec.Type.STRING, "TESTS_MEMOS_TOKEN", System.getenv("TESTS_MEMOS_TOKEN") ?: properties.getProperty("TESTS_MEMOS_TOKEN") ?: "")
     }
 }
 

--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -56,6 +56,9 @@ import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookApiImpl
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
 import coredevices.ring.external.indexwebhook.IndexWebhookRunRepository
+import coredevices.ring.agent.integrations.memos.MemosApi
+import coredevices.ring.agent.integrations.memos.MemosApiImpl
+import coredevices.ring.agent.integrations.memos.MemosPreferences
 import coredevices.ring.agent.integrations.obsidian.ObsidianPreferences
 import coredevices.ring.firestoreModule
 import coredevices.ring.mcpModule
@@ -211,6 +214,8 @@ val experimentalModule = module {
     singleOf(::IndexWebhookRunRepository)
     singleOf(::GestureRoutingPreferences)
     singleOf(::ObsidianPreferences)
+    singleOf(::MemosPreferences)
+    singleOf(::MemosApiImpl) bind MemosApi::class
     single {
         IndexWebhookApiImpl(
             get(),

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteIntegrationFactory.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteIntegrationFactory.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import coredevices.ring.agent.integrations.DelegatingNoteIntegration
 import coredevices.ring.agent.integrations.NoteIntegration
 import coredevices.ring.agent.integrations.NotionIntegration
+import coredevices.ring.agent.integrations.memos.MemosIntegration
 import coredevices.ring.agent.integrations.obsidian.ObsidianIntegration
 import coredevices.ring.database.Preferences
 import coredevices.firestore.UsersDao
@@ -24,6 +25,7 @@ class NoteIntegrationFactory(
             NoteProvider.Notion -> delegated(get<NotionIntegration>(), integration)
             NoteProvider.Obsidian -> delegated(get<ObsidianIntegration>(), integration)
             NoteProvider.Tasker -> delegated(createTaskerNoteClient(), integration)
+            NoteProvider.Memos -> delegated(get<MemosIntegration>(), integration)
         }
     }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteProvider.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/builtin_servlets/notes/NoteProvider.kt
@@ -4,7 +4,8 @@ enum class NoteProvider(val id: Int, val title: String) {
     Builtin(1, "Builtin Notes"),
     Notion(2, "Notion"),
     Tasker(3, "Tasker"),
-    Obsidian(4, "Obsidian");
+    Obsidian(4, "Obsidian"),
+    Memos(5, "Memos");
 
     companion object {
         fun fromId(id: Int): NoteProvider? = entries.find { it.id == id }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/memos/MemosApi.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/memos/MemosApi.kt
@@ -1,0 +1,62 @@
+package coredevices.ring.agent.integrations.memos
+
+import co.touchlab.kermit.Logger
+import coredevices.ring.api.ApiConfig
+import coredevices.api.ApiClient
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+data class CreateMemoRequest(
+    val baseUrl: String,
+    val token: String,
+    val content: String,
+)
+
+interface MemosApi {
+    /** Returns the created memo's resource name. Throws if the server rejected the note. */
+    suspend fun createMemo(request: CreateMemoRequest): String
+
+    /** True when the server accepts the token. */
+    suspend fun validateCredentials(baseUrl: String, token: String): Boolean
+}
+
+class MemosApiImpl(config: ApiConfig) : ApiClient(config.version), MemosApi {
+
+    companion object {
+        private val logger = Logger.withTag("MemosApi")
+    }
+
+    override suspend fun createMemo(request: CreateMemoRequest): String {
+        val response = client.post("${request.baseUrl}/api/v1/memos") {
+            bearerAuth(request.token)
+            contentType(ContentType.Application.Json)
+            setBody(buildJsonObject { put("content", request.content) })
+        }
+        // CreateNoteTool reports a null return as a saved note; only an exception surfaces failure.
+        if (!response.status.isSuccess()) {
+            error("Memos rejected the note: ${response.status}")
+        }
+        return response.body<JsonObject>()["name"]?.jsonPrimitive?.contentOrNull
+            ?: error("Memos returned no memo name")
+    }
+
+    override suspend fun validateCredentials(baseUrl: String, token: String): Boolean {
+        val response = client.get("$baseUrl/api/v1/auth/me") { bearerAuth(token) }
+        if (!response.status.isSuccess()) {
+            logger.w { "Memos rejected credentials: ${response.status}" }
+            return false
+        }
+        return true
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/memos/MemosIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/memos/MemosIntegration.kt
@@ -1,0 +1,57 @@
+package coredevices.ring.agent.integrations.memos
+
+import PlatformUiContext
+import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
+import coredevices.ring.agent.integrations.ItemSource
+import coredevices.ring.agent.integrations.NoteIntegration
+import coredevices.ring.data.IntegrationDefinition
+import coredevices.util.integrations.IntegrationAuthException
+import coredevices.util.integrations.IntegrationTokenStorage
+
+/**
+ * Posts notes to a self-hosted [Memos](https://usememos.com) server. The user supplies the server
+ * URL and an access token, so there is no OAuth flow to run.
+ */
+class MemosIntegration(
+    private val api: MemosApi,
+    private val prefs: MemosPreferences,
+    private val tokenStorage: IntegrationTokenStorage,
+) : NoteIntegration {
+
+    companion object {
+        const val TOKEN_KEY = "memos"
+        val DEFINITION = IntegrationDefinition(
+            title = "Memos",
+            reminder = null,
+            notes = NoteProvider.Memos,
+        )
+    }
+
+    /** Stores the server and token only once the server has confirmed they work. */
+    suspend fun connect(baseUrl: String, token: String): Boolean {
+        val normalized = baseUrl.trim().trimEnd('/')
+        if (!api.validateCredentials(normalized, token)) return false
+        prefs.setBaseUrl(normalized)
+        tokenStorage.saveToken(TOKEN_KEY, token)
+        return true
+    }
+
+    override suspend fun signIn(uiContext: PlatformUiContext): Boolean = isAuthorized()
+
+    override suspend fun unlink() {
+        tokenStorage.deleteToken(TOKEN_KEY)
+        prefs.clear()
+    }
+
+    override suspend fun isAuthorized(): Boolean =
+        prefs.baseUrl.value != null && tokenStorage.getToken(TOKEN_KEY) != null
+
+    override suspend fun createNote(content: String, source: ItemSource?): String {
+        val baseUrl = prefs.baseUrl.value
+        val token = tokenStorage.getToken(TOKEN_KEY)
+        if (baseUrl == null || token == null) {
+            throw IntegrationAuthException("Memos is not configured")
+        }
+        return api.createMemo(CreateMemoRequest(baseUrl, token, content))
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/memos/MemosPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/memos/MemosPreferences.kt
@@ -1,0 +1,30 @@
+package coredevices.ring.agent.integrations.memos
+
+import com.russhwolf.settings.Settings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Persists the Memos server to post notes to. The access token is a secret and lives in
+ * `IntegrationTokenStorage` instead.
+ */
+class MemosPreferences(private val settings: Settings) {
+
+    companion object {
+        private const val BASE_URL_KEY = "memos_base_url"
+    }
+
+    private val _baseUrl = MutableStateFlow(settings.getStringOrNull(BASE_URL_KEY))
+    val baseUrl = _baseUrl.asStateFlow()
+
+    fun setBaseUrl(url: String) {
+        val normalized = url.trim().trimEnd('/').ifBlank { null }
+        if (normalized == null) settings.remove(BASE_URL_KEY) else settings.putString(BASE_URL_KEY, normalized)
+        _baseUrl.value = normalized
+    }
+
+    fun clear() {
+        settings.remove(BASE_URL_KEY)
+        _baseUrl.value = null
+    }
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/mcpModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/mcpModule.kt
@@ -11,6 +11,7 @@ import coredevices.ring.agent.builtin_servlets.notes.NoteIntegrationFactory
 import coredevices.ring.database.Preferences
 import coredevices.ring.database.room.repository.McpSandboxRepository
 import coredevices.ring.agent.integrations.NotionIntegration
+import coredevices.ring.agent.integrations.memos.MemosIntegration
 import coredevices.ring.agent.integrations.obsidian.ObsidianIntegration
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
@@ -35,6 +36,7 @@ internal val mcpModule = module {
     // constructor defaults are used — Koin's factoryOf would try to resolve every
     // parameter from the graph and fail on kotlinx.datetime.TimeZone.
     factory { ObsidianIntegration(get(), get()) }
+    factoryOf(::MemosIntegration)
     factoryOf(::LocalNoteClient)
     singleOf(::NoteIntegrationFactory)
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
@@ -48,6 +49,8 @@ import coredevices.ring.agent.builtin_servlets.notes.NoteProvider
 import coredevices.ring.agent.builtin_servlets.notes.TASKER_DEFINITION
 import coredevices.ring.agent.integrations.GTasksIntegration
 import coredevices.ring.agent.integrations.NotionIntegration
+import coredevices.ring.agent.integrations.memos.MemosIntegration
+import coredevices.ring.agent.integrations.memos.MemosPreferences
 import coredevices.ring.agent.integrations.obsidian.ObsidianIntegration
 import coredevices.ring.agent.integrations.obsidian.ObsidianMode
 import coredevices.ring.agent.integrations.obsidian.ObsidianPreferences
@@ -124,6 +127,16 @@ fun AddIntegration(coreNav: CoreNav) {
                 Item(def) {
                     dialog = {
                         ObsidianDialog(
+                            onDismiss = { dialog = null }
+                        )
+                    }
+                }
+            }
+            item {
+                val def = remember { MemosIntegration.DEFINITION }
+                Item(def) {
+                    dialog = {
+                        MemosDialog(
                             onDismiss = { dialog = null }
                         )
                     }
@@ -748,6 +761,101 @@ fun TaskerDialog(
             }
             is SignInState.Success -> {
                 Text("Tasker connected. Choose it for notes or reminders in Index settings.")
+            }
+            is SignInState.Error -> {
+                Text(
+                    "Error: ${s.message}",
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun MemosDialog(
+    onDismiss: () -> Unit
+) {
+    val integration = koinInject<MemosIntegration>()
+    val prefs = koinInject<MemosPreferences>()
+    var serverUrl by remember { mutableStateOf(prefs.baseUrl.value ?: "") }
+    var token by remember { mutableStateOf("") }
+    var state by remember { mutableStateOf<SignInState>(SignInState.Idle) }
+    val scope = rememberCoroutineScope()
+
+    M3Dialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Memos") },
+        buttons = {
+            TextButton(onClick = onDismiss) {
+                Text(if (state is SignInState.Success) "Done" else "Cancel")
+            }
+            if (state !is SignInState.Success) {
+                Spacer(Modifier.width(8.dp))
+                TextButton(
+                    enabled = state !is SignInState.SigningIn &&
+                        serverUrl.isNotBlank() && token.isNotBlank(),
+                    onClick = {
+                        state = SignInState.SigningIn
+                        scope.launch {
+                            state = try {
+                                if (integration.connect(serverUrl, token)) {
+                                    SignInState.Success
+                                } else {
+                                    SignInState.Error(
+                                        "Could not reach that server, or the token was rejected."
+                                    )
+                                }
+                            } catch (e: Throwable) {
+                                Logger.w("AddIntegration", e) { "Error connecting Memos: ${e.message}" }
+                                SignInState.Error(e.message ?: "Unknown error")
+                            }
+                        }
+                    }
+                ) {
+                    Text("Connect")
+                }
+            }
+        }
+    ) {
+        when (val s = state) {
+            is SignInState.Idle -> {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Saves your notes to a self-hosted Memos server.")
+                    OutlinedTextField(
+                        value = serverUrl,
+                        onValueChange = { serverUrl = it },
+                        label = { Text("Server URL") },
+                        placeholder = { Text("https://memos.example.com") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = token,
+                        onValueChange = { token = it },
+                        label = { Text("Access token") },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Text(
+                        "Create a token in Memos under Settings \u2192 My Account \u2192 Access Tokens.",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+            is SignInState.SigningIn -> {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            is SignInState.Success -> {
+                Text("Memos connected. Choose it for notes in Index settings.")
             }
             is SignInState.Error -> {
                 Text(

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexActionsSection.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/IndexActionsSection.kt
@@ -140,6 +140,7 @@ internal fun actionConnectDialog(action: IndexAction): ActionsDialog? =
 internal fun noteConnectDialog(provider: NoteProvider): ActionsDialog? = when (provider) {
     NoteProvider.Notion -> ActionsDialog.Notion
     NoteProvider.Obsidian -> ActionsDialog.Obsidian
+    NoteProvider.Memos -> ActionsDialog.Memos
     NoteProvider.Tasker -> ActionsDialog.Tasker
     NoteProvider.Builtin -> null
 }
@@ -182,7 +183,7 @@ private fun presentationFor(action: IndexAction): ActionPresentation = when (act
 }
 
 private enum class ActionsSheet { CaptureType, NoteDestination, ReminderDestination }
-internal enum class ActionsDialog { AddServer, Sideload, Notion, GoogleTasks, Obsidian, Tasker, PhoneCalendar }
+internal enum class ActionsDialog { AddServer, Sideload, Notion, GoogleTasks, Obsidian, Memos, Tasker, PhoneCalendar }
 
 @Composable
 fun IndexActionsSection(
@@ -368,6 +369,7 @@ fun IndexActionsSection(
         ActionsDialog.Notion -> NotionDialog(onDismiss = closeConnectDialog)
         ActionsDialog.GoogleTasks -> GTasksDialog(onDismiss = closeConnectDialog)
         ActionsDialog.Obsidian -> ObsidianDialog(onDismiss = closeConnectDialog)
+        ActionsDialog.Memos -> MemosDialog(onDismiss = closeConnectDialog)
         ActionsDialog.Tasker -> TaskerDialog(onDismiss = closeConnectDialog)
         ActionsDialog.PhoneCalendar -> PhoneCalendarDialog(onDismiss = { dialog = null })
         null -> {}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/memos/MemosApiIntegrationTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/memos/MemosApiIntegrationTest.kt
@@ -1,0 +1,82 @@
+package coredevices.ring.agent.integrations.memos
+
+import coredevices.ring.BuildKonfig
+import coredevices.ring.api.ApiConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import kotlinx.coroutines.runBlocking
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Talks to a real Memos server. Set TESTS_MEMOS_URL and TESTS_MEMOS_TOKEN (env var or gradle
+ * property) and drop the @Ignore to run one of these.
+ */
+class MemosApiIntegrationTest {
+
+    private val baseUrl = BuildKonfig.TESTS_MEMOS_URL.trimEnd('/')
+    private val token = BuildKonfig.TESTS_MEMOS_TOKEN
+
+    private fun api() = MemosApiImpl(
+        ApiConfig(
+            nenyaUrl = "",
+            notionOAuthBackendUrl = "",
+            notionApiUrl = "",
+            bugUrl = "",
+            version = "",
+            tokenUrl = "",
+        )
+    )
+
+    @BeforeTest
+    fun setUp() {
+        stopKoin()
+        startKoin {
+            modules(
+                module {
+                    factory {
+                        HttpClient().engine
+                    } bind HttpClientEngine::class
+                }
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Ignore
+    @Test
+    fun acceptsValidCredentials() = runBlocking {
+        assertTrue(api().validateCredentials(baseUrl, token))
+    }
+
+    @Ignore
+    @Test
+    fun rejectsABadToken() = runBlocking {
+        assertFalse(api().validateCredentials(baseUrl, "definitely-not-a-real-token"))
+    }
+
+    @Ignore
+    @Test
+    fun createsAMemo() = runBlocking {
+        val name = api().createMemo(
+            CreateMemoRequest(
+                baseUrl = baseUrl,
+                token = token,
+                content = "Index integration test — safe to delete",
+            )
+        )
+        assertTrue(name.isNotEmpty())
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/memos/MemosIntegrationTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/memos/MemosIntegrationTest.kt
@@ -1,0 +1,154 @@
+package coredevices.ring.agent.integrations.memos
+
+import com.russhwolf.settings.MapSettings
+import coredevices.util.integrations.IntegrationAuthException
+import coredevices.util.integrations.IntegrationTokenStorage
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MemosIntegrationTest {
+
+    private class FakeMemosApi(
+        private val result: String = "memos/42",
+        private val credentialsValid: Boolean = true,
+        private val createFails: Boolean = false,
+    ) : MemosApi {
+        val calls = mutableListOf<CreateMemoRequest>()
+        val validations = mutableListOf<Pair<String, String>>()
+        override suspend fun createMemo(request: CreateMemoRequest): String {
+            calls += request
+            if (createFails) error("server said no")
+            return result
+        }
+        override suspend fun validateCredentials(baseUrl: String, token: String): Boolean {
+            validations += baseUrl to token
+            return credentialsValid
+        }
+    }
+
+    private class FakeTokenStorage : IntegrationTokenStorage {
+        private val tokens = mutableMapOf<String, String>()
+        override suspend fun saveToken(key: String, token: String) { tokens[key] = token }
+        override suspend fun getToken(key: String): String? = tokens[key]
+        override suspend fun deleteToken(key: String) { tokens.remove(key) }
+    }
+
+    private fun configured(
+        api: MemosApi = FakeMemosApi(),
+        prefs: MemosPreferences = MemosPreferences(MapSettings()),
+        tokens: FakeTokenStorage = FakeTokenStorage(),
+    ) = Triple(MemosIntegration(api, prefs, tokens), prefs, tokens)
+
+    @Test
+    fun createNoteSendsContentToTheConfiguredServer() = runTest {
+        val api = FakeMemosApi()
+        val (integration, prefs, tokens) = configured(api = api)
+        prefs.setBaseUrl("https://memos.example.com")
+        tokens.saveToken(MemosIntegration.TOKEN_KEY, "tok-abc")
+
+        val id = integration.createNote("remember the milk", source = null)
+
+        assertEquals("memos/42", id)
+        assertEquals(1, api.calls.size)
+        val call = api.calls.single()
+        assertEquals("https://memos.example.com", call.baseUrl)
+        assertEquals("tok-abc", call.token)
+        assertEquals("remember the milk", call.content)
+    }
+
+    @Test
+    fun createNoteFailsLoudlyWithoutAServer() = runTest {
+        val api = FakeMemosApi()
+        val (integration, _, tokens) = configured(api = api)
+        tokens.saveToken(MemosIntegration.TOKEN_KEY, "tok-abc")
+
+        assertFailsWith<IntegrationAuthException> { integration.createNote("orphan", source = null) }
+        assertTrue(api.calls.isEmpty())
+    }
+
+    @Test
+    fun createNoteFailsLoudlyWithoutAToken() = runTest {
+        val api = FakeMemosApi()
+        val (integration, prefs, _) = configured(api = api)
+        prefs.setBaseUrl("https://memos.example.com")
+
+        assertFailsWith<IntegrationAuthException> { integration.createNote("orphan", source = null) }
+        assertTrue(api.calls.isEmpty())
+    }
+
+    @Test
+    fun aRejectedNoteIsNotReportedAsSaved() = runTest {
+        val api = FakeMemosApi(createFails = true)
+        val (integration, prefs, tokens) = configured(api = api)
+        prefs.setBaseUrl("https://memos.example.com")
+        tokens.saveToken(MemosIntegration.TOKEN_KEY, "tok-abc")
+
+        assertFailsWith<IllegalStateException> { integration.createNote("dropped", source = null) }
+    }
+
+    @Test
+    fun authorizedOnlyWhenServerAndTokenAreBothPresent() = runTest {
+        val (integration, prefs, tokens) = configured()
+        assertFalse(integration.isAuthorized())
+
+        prefs.setBaseUrl("https://memos.example.com")
+        assertFalse(integration.isAuthorized())
+
+        tokens.saveToken(MemosIntegration.TOKEN_KEY, "tok-abc")
+        assertTrue(integration.isAuthorized())
+    }
+
+    @Test
+    fun unlinkForgetsServerAndToken() = runTest {
+        val (integration, prefs, tokens) = configured()
+        prefs.setBaseUrl("https://memos.example.com")
+        tokens.saveToken(MemosIntegration.TOKEN_KEY, "tok-abc")
+
+        integration.unlink()
+
+        assertNull(prefs.baseUrl.value)
+        assertNull(tokens.getToken(MemosIntegration.TOKEN_KEY))
+        assertFalse(integration.isAuthorized())
+    }
+
+    @Test
+    fun connectingVerifiesCredentialsBeforeSavingThem() = runTest {
+        val api = FakeMemosApi()
+        val (integration, prefs, tokens) = configured(api = api)
+
+        assertTrue(integration.connect("https://memos.example.com/", "tok-abc"))
+
+        assertEquals("https://memos.example.com" to "tok-abc", api.validations.single())
+        assertEquals("https://memos.example.com", prefs.baseUrl.value)
+        assertEquals("tok-abc", tokens.getToken(MemosIntegration.TOKEN_KEY))
+    }
+
+    @Test
+    fun rejectedCredentialsAreNotSaved() = runTest {
+        val api = FakeMemosApi(credentialsValid = false)
+        val (integration, prefs, tokens) = configured(api = api)
+
+        assertFalse(integration.connect("https://memos.example.com", "bad-token"))
+
+        assertNull(prefs.baseUrl.value)
+        assertNull(tokens.getToken(MemosIntegration.TOKEN_KEY))
+    }
+
+    @Test
+    fun aFailedConnectLeavesAnEarlierServerIntact() = runTest {
+        val api = FakeMemosApi(credentialsValid = false)
+        val (integration, prefs, tokens) = configured(api = api)
+        prefs.setBaseUrl("https://good.example.com")
+        tokens.saveToken(MemosIntegration.TOKEN_KEY, "good-token")
+
+        assertFalse(integration.connect("https://bad.example.com", "bad-token"))
+
+        assertEquals("https://good.example.com", prefs.baseUrl.value)
+        assertEquals("good-token", tokens.getToken(MemosIntegration.TOKEN_KEY))
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/memos/MemosPreferencesTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/memos/MemosPreferencesTest.kt
@@ -1,0 +1,43 @@
+package coredevices.ring.agent.integrations.memos
+
+import com.russhwolf.settings.MapSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MemosPreferencesTest {
+
+    @Test
+    fun defaultsToNoServer() {
+        assertNull(MemosPreferences(MapSettings()).baseUrl.value)
+    }
+
+    @Test
+    fun baseUrlRoundTripsThroughSettings() {
+        val settings = MapSettings()
+        MemosPreferences(settings).setBaseUrl("https://memos.example.com")
+        assertEquals("https://memos.example.com", MemosPreferences(settings).baseUrl.value)
+    }
+
+    @Test
+    fun baseUrlDropsTrailingSlashes() {
+        val prefs = MemosPreferences(MapSettings())
+        prefs.setBaseUrl("https://memos.example.com//")
+        assertEquals("https://memos.example.com", prefs.baseUrl.value)
+    }
+
+    @Test
+    fun blankBaseUrlIsStoredAsUnset() {
+        val prefs = MemosPreferences(MapSettings())
+        prefs.setBaseUrl("   ")
+        assertNull(prefs.baseUrl.value)
+    }
+
+    @Test
+    fun clearForgetsTheServer() {
+        val prefs = MemosPreferences(MapSettings())
+        prefs.setBaseUrl("https://memos.example.com")
+        prefs.clear()
+        assertNull(prefs.baseUrl.value)
+    }
+}


### PR DESCRIPTION
I have a self-hosted [Memos](https://usememos.com) server that I was previously using for saving voice memos with a "shake" gesture on my phone. Now that my Index 01 has arrived, I'd like to set it up to point at the same thing.

I looked at potentially doing this with webhooks or tasker, but the former would send form-data instead of the json blob Memos would recognize, and the latter was going to involve a fair bit of setup, and a paid app I don't currently own.  So I opted to try and build it into the app as another integration option.  I figured I'd open a PR here, in case it seemed like an integration that might be useful to anyone else.

This was done AI assisted, but under careful manual guidance, and I think I've landed on a reasonable implementation.  I've been able to test through the flow (configure the integration, type a note, submit with local llm, and see it show up on my server) on an Android emulator.  I don't have an iOS device available, so I've only been able to do the CI build for that one, although I can't see any obvious reason it wouldn't work.

I tried to mostly follow the existing patterns established by the Obsidian and Notion integrations, but may have missed some things. I did opt to put the new integration into a subdirectory in `integrations/` like obsidian, to try and keep things organized as best as I could. I also added another test similar to the `NotionNoteClientIntegrationTest` called `MemosApiIntegrationTest`, that hits a real server, pulling credentials from env vars or gradle props (`@Ignore`'d by default, like the notion one, to keep it out of the CI test runs where there aren't credentials available).

On a mostly unrelated note, I did notice while I was building this that there doesn't currently appear to be any way to *edit* an integration setup once it's been added. Discovered that the hard way after accidentally typo-ing the URL and having to reset the emulator to do it again from scratch.  Not something I wanted to scope-creep into this PR, but figured I'd mention it anyway.

<img width="270" height="600" alt="1-connect-dialog-blurred" src="https://github.com/user-attachments/assets/86ed7ed5-2d12-4d50-b472-75acf026078b" />
<img width="270" height="600" alt="4-sent-to-memos" src="https://github.com/user-attachments/assets/773890d2-54d8-4b1a-91df-cb7ed2f7f64f" />
<img width="600" height="100" alt="5-memo-on-server" src="https://github.com/user-attachments/assets/7b9c72de-f3db-4c63-a8b5-fcfdf9d1b088" />
