### PR TITLE
[New Feature] Webhook HMAC signing

### DIFF
--- a/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
+++ b/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
@@ -667,6 +667,8 @@ class RingRecordingE2ETest {
                     gesture: coredevices.ring.service.button.RingGesture,
                     url: String,
                     headers: Map<String, String>,
+                    signRequests: Boolean,
+                    signingSecret: String?,
                 ) = coredevices.ring.external.indexwebhook.IndexWebhookRunResult(
                     ok = true, status = "200 OK", detail = "test event", byteSize = 0, durationMs = 0,
                 )

--- a/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
+++ b/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
@@ -265,6 +265,8 @@ class RecordingProcessingQueueTest {
                     gesture: coredevices.ring.service.button.RingGesture,
                     url: String,
                     headers: Map<String, String>,
+                    signRequests: Boolean,
+                    signingSecret: String?,
                 ) = coredevices.ring.external.indexwebhook.IndexWebhookRunResult(
                     ok = true, status = "200 OK", detail = "test event", byteSize = 0, durationMs = 0,
                 )

--- a/experimental/src/androidMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigning.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigning.android.kt
@@ -1,0 +1,10 @@
+package coredevices.ring.external.indexwebhook
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+internal actual fun hmacSha256(key: ByteArray, message: ByteArray): ByteArray =
+    Mac.getInstance("HmacSHA256").run {
+        init(SecretKeySpec(key, "HmacSHA256"))
+        doFinal(message)
+    }

--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -55,6 +55,7 @@ import coredevices.libindex.database.repository.RingTransferRepository
 import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookApiImpl
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
+import coredevices.ring.external.indexwebhook.IndexWebhookSigningSecretStorage
 import coredevices.ring.external.indexwebhook.IndexWebhookRunRepository
 import coredevices.ring.agent.integrations.obsidian.ObsidianPreferences
 import coredevices.ring.firestoreModule
@@ -208,11 +209,13 @@ val experimentalModule = module {
     singleOf(::GoogleTasksApi)
     singleOf(::M4aEncoder)
     singleOf(::IndexWebhookPreferences)
+    singleOf(::IndexWebhookSigningSecretStorage)
     singleOf(::IndexWebhookRunRepository)
     singleOf(::GestureRoutingPreferences)
     singleOf(::ObsidianPreferences)
     single {
         IndexWebhookApiImpl(
+            get(),
             get(),
             get(),
             get(),

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
@@ -8,8 +8,9 @@ Send Index ring recording data to any HTTP endpoint.
 2. Pick the gesture to configure: **Hold & talk** or **Double click & hold**. Each gesture has its own endpoint, headers and payload mode
 3. Enter your webhook URL
 4. Add any request headers you need (e.g. an auth header)
-5. Choose what to send: Recording only, Transcription only, or Both
-6. Optionally tap **Send test event** to verify the endpoint, then **Save**
+5. Optionally enable **Sign requests** and enter the same signing secret used by your server
+6. Choose what to send: Recording only, Transcription only, or Both
+7. Optionally tap **Send test event** to verify the endpoint, then **Save**
 
 A gesture only sends once its config is saved with a URL. The switch turns sending off without discarding the URL and headers, and the last 20 runs per gesture are listed under **Recent runs**.
 
@@ -20,8 +21,12 @@ POST <your webhook URL>
 Content-Type: multipart/form-data; boundary=<uuid>
 <each user-configured header>
 X-Audio-Size: <byte count>  (when audio is included)
+X-Index-Webhook-Version: 1
 X-Index-Trigger: single-click-hold | double-click-hold | test-event
 X-Index-Test: true  (test events only)
+X-Index-Signature: <lowercase hex HMAC-SHA256>  (when signing is enabled)
+X-Index-Timestamp: <Unix time in seconds>  (when signing is enabled)
+X-Index-Delivery: <stable delivery ID>  (when signing is enabled)
 ```
 
 ## Multipart Fields
@@ -66,26 +71,111 @@ Headers are fully user-configurable in the webhook settings — add as many name
 
 `X-Audio-Size` is still added automatically when audio is included (it carries the audio byte count) and cannot be overridden.
 
-`X-Index-Trigger` is added automatically to identify the gesture that started the recording — `single-click-hold`, `double-click-hold`, or `test-event` for a manually sent test. The gesture is persisted with the processing task and preserved when a failed recording is retried. Recordings with no known gesture do not fire a webhook at all. Neither `X-Index-Trigger` nor `X-Index-Test` can be overridden by a user-configured header.
+`X-Index-Trigger` is added automatically to identify the gesture that started the recording — `single-click-hold`, `double-click-hold`, or `test-event` for a manually sent test. The gesture is persisted with the processing task and preserved when a failed recording is retried. Recordings with no known gesture do not fire a webhook at all.
+
+`X-Index-Webhook-Version` is sent on every request and versions the complete webhook protocol, including its automatic headers, multipart fields, and signing rules. This document describes version `1`. A missing version identifies a request from an older, pre-version app build; receivers that depend on a particular contract should require a supported explicit version.
+
+User-configured headers cannot override `X-Audio-Size`, `X-Index-Webhook-Version`, `X-Index-Trigger`, `X-Index-Test`, `X-Index-Signature`, `X-Index-Timestamp`, or `X-Index-Delivery`. Header-name matching is case-insensitive.
 
 > Migration note: a previously configured single webhook is copied to both recording gestures, and an auth token configured before headers were user-settable is carried over as an `X-Widget-Token` header.
 
-## Authentication
+## Protocol versioning
 
-Authentication is whatever your headers say it is. The original integration used an `X-Widget-Token` header; the example below keeps that convention, but any scheme works.
+Increment `X-Index-Webhook-Version` only for receiver-visible breaking changes, such as renaming or removing automatic headers or multipart fields, changing field semantics or encoding, or changing the signed-byte format. Backward-compatible additions remain on the current version; receivers should ignore headers and multipart fields they do not use.
 
-## Example: Receiving with a simple server
+Record every version change in this document, including migration guidance when applicable.
+
+- **Version 1:** Current multipart request contract and optional HMAC-SHA256 signing protocol documented below.
+
+## Signed requests
+
+Request signing is optional and configured independently for each recording gesture. The secret is stored in Android Keystore-backed encrypted storage or Apple Keychain, rather than in the normal webhook settings JSON. If signing is enabled but the secret cannot be read, the request fails without sending an unsigned fallback.
+
+The app signs these exact bytes:
+
+```text
+UTF8(
+  "v1\n" +
+  timestamp + "\n" +
+  deliveryId + "\n" +
+  trigger + "\n" +
+  (isTest ? "1" : "0") + "\n"
+) || rawMultipartBodyBytes
+```
+
+The signing key is the UTF-8 byte sequence of the secret exactly as entered. The signature header is:
+
+```text
+X-Index-Signature: <lowercase hex HMAC-SHA256(signingKey, bytesAbove)>
+```
+
+The leading `v1` in the signed bytes authenticates `X-Index-Webhook-Version: 1`; a receiver must use the header value to reconstruct that prefix. For a recording, `X-Index-Delivery` is the stable recording delivery identifier. A test event gets a fresh UUID. `X-Index-Timestamp` is generated when the request is sent.
+
+Receivers should:
+
+1. Require HTTPS.
+2. Read the raw request body before parsing multipart fields.
+3. Reject unsupported webhook versions and malformed timestamps.
+4. Reconstruct the signed bytes and compare signatures in constant time.
+5. Reject timestamps outside a short window; five minutes is a reasonable default.
+6. Cache accepted delivery IDs for at least that window and reject replays.
+
+Use a unique, cryptographically random secret for each endpoint. At least 32 random bytes encoded as base64url or hex is recommended. Do not use a memorable password or reuse an API token.
+
+HMAC authenticates the request and detects modification; it does not encrypt the recording or transcription. HTTPS is still required.
+
+## Other authentication
+
+Custom headers can still carry another authentication scheme alongside request signing. The original integration used an `X-Widget-Token` header, but any scheme works.
+
+## Example: Verifying a signed request
 
 ```python
+import hashlib
+import hmac
+import os
+import time
+
 from flask import Flask, request
 
 app = Flask(__name__)
+secret = os.environ["INDEX_WEBHOOK_SECRET"].encode("utf-8")
+seen_deliveries = {}
 
 @app.route('/webhook', methods=['POST'])
 def receive():
-    token = request.headers.get('X-Widget-Token')
-    if token != 'your-secret-token':
-        return 'Unauthorized', 401
+    raw_body = request.get_data(cache=True)
+    webhook_version = request.headers.get('X-Index-Webhook-Version', '')
+    signature = request.headers.get('X-Index-Signature', '')
+    timestamp_text = request.headers.get('X-Index-Timestamp', '')
+    delivery_id = request.headers.get('X-Index-Delivery', '')
+    trigger = request.headers.get('X-Index-Trigger', '')
+    is_test = request.headers.get('X-Index-Test') == 'true'
+
+    if webhook_version != '1':
+        return 'Unsupported webhook version', 400
+
+    try:
+        timestamp = int(timestamp_text)
+    except ValueError:
+        return 'Invalid timestamp', 400
+
+    now = int(time.time())
+    if abs(now - timestamp) > 300:
+        return 'Expired request', 401
+
+    prefix = f"v{webhook_version}\n{timestamp}\n{delivery_id}\n{trigger}\n{1 if is_test else 0}\n"
+    expected = hmac.new(
+        secret,
+        prefix.encode('utf-8') + raw_body,
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        return 'Invalid signature', 401
+
+    if delivery_id in seen_deliveries:
+        return 'Duplicate delivery', 409
+    seen_deliveries[delivery_id] = now
 
     audio = request.files.get('audio')
     transcription = request.form.get('transcription')
@@ -103,6 +193,8 @@ def receive():
     print(f'Trigger: {trigger}')
     return 'OK', 200
 ```
+
+The in-memory replay cache above is only illustrative. A production service should expire entries and use a shared TTL store when more than one server instance accepts webhooks.
 
 ## Notes
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
@@ -46,6 +46,8 @@ interface IndexWebhookApi {
         gesture: RingGesture,
         url: String,
         headers: Map<String, String>,
+        signRequests: Boolean,
+        signingSecret: String?,
     ): IndexWebhookRunResult
 }
 
@@ -65,6 +67,8 @@ val RingGesture.webhookTriggerValue: String
     }
 
 internal const val WEBHOOK_AUDIO_SIZE_HEADER = "X-Audio-Size"
+internal const val WEBHOOK_VERSION_HEADER = "X-Index-Webhook-Version"
+internal const val WEBHOOK_VERSION = "1"
 internal const val WEBHOOK_TRIGGER_HEADER = "X-Index-Trigger"
 internal const val WEBHOOK_TEST_HEADER = "X-Index-Test"
 internal const val WEBHOOK_TEST_TRIGGER = "test-event"
@@ -78,6 +82,7 @@ class IndexWebhookApiImpl(
     config: ApiConfig,
     private val m4aEncoder: M4aEncoder,
     private val webhookPreferences: IndexWebhookPreferences,
+    private val signingSecretStorage: IndexWebhookSigningSecretStorage,
     private val runRepository: IndexWebhookRunRepository,
     private val scope: CoroutineScope,
 ) : IndexWebhookApi, ApiClient(config.version, timeout = 2.minutes) {
@@ -113,9 +118,21 @@ class IndexWebhookApiImpl(
                     config.payloadMode != IndexWebhookPayloadMode.RecordingOnly
                 ) transcription else null
 
+                val signingSecret = if (config.signRequests) {
+                    try {
+                        signingSecretStorage.get(gesture)
+                    } catch (e: Exception) {
+                        logger.e(e) { "Could not read webhook signing secret" }
+                        null
+                    }
+                } else null
+
                 val result = post(
                     url = url,
                     headers = config.headers,
+                    signRequests = config.signRequests,
+                    signingSecret = signingSecret,
+                    deliveryId = recordingId,
                     triggerValue = gesture.webhookTriggerValue,
                     audioData = m4aData,
                     filename = "$recordingId.m4a",
@@ -146,10 +163,15 @@ class IndexWebhookApiImpl(
         gesture: RingGesture,
         url: String,
         headers: Map<String, String>,
+        signRequests: Boolean,
+        signingSecret: String?,
     ): IndexWebhookRunResult {
         val result = post(
             url = url,
             headers = headers,
+            signRequests = signRequests,
+            signingSecret = signingSecret,
+            deliveryId = Uuid.random().toString(),
             triggerValue = WEBHOOK_TEST_TRIGGER,
             audioData = null,
             filename = null,
@@ -171,6 +193,9 @@ class IndexWebhookApiImpl(
     private suspend fun post(
         url: String,
         headers: Map<String, String>,
+        signRequests: Boolean,
+        signingSecret: String?,
+        deliveryId: String,
         triggerValue: String,
         audioData: ByteArray?,
         filename: String?,
@@ -189,16 +214,38 @@ class IndexWebhookApiImpl(
         )
         val started = TimeSource.Monotonic.markNow()
         return try {
+            val timestamp = Clock.System.now().toEpochMilliseconds() / 1000
+            val signature = if (signRequests) {
+                if (signingSecret.isNullOrBlank()) {
+                    return IndexWebhookRunResult(
+                        ok = false,
+                        status = "SIGNING ERROR",
+                        detail = "Signing secret is missing",
+                        byteSize = bodyBytes.size.toLong(),
+                        durationMs = started.elapsedNow().inWholeMilliseconds,
+                    )
+                }
+                createWebhookSignature(
+                    secret = signingSecret,
+                    timestamp = timestamp,
+                    deliveryId = deliveryId,
+                    triggerValue = triggerValue,
+                    isTest = isTest,
+                    body = bodyBytes,
+                )
+            } else null
             val response = client.post(url) {
-                headers
-                    .filterKeys {
-                        !it.equals(WEBHOOK_TRIGGER_HEADER, ignoreCase = true) &&
-                            !it.equals(WEBHOOK_TEST_HEADER, ignoreCase = true)
-                    }
+                headers.withoutReservedWebhookHeaders()
                     .forEach { (name, value) -> header(name, value) }
+                header(WEBHOOK_VERSION_HEADER, WEBHOOK_VERSION)
                 header(WEBHOOK_TRIGGER_HEADER, triggerValue)
                 if (isTest) header(WEBHOOK_TEST_HEADER, "true")
                 if (audioData != null) header(WEBHOOK_AUDIO_SIZE_HEADER, audioData.size.toString())
+                if (signature != null) {
+                    header(WEBHOOK_SIGNATURE_HEADER, signature)
+                    header(WEBHOOK_TIMESTAMP_HEADER, timestamp.toString())
+                    header(WEBHOOK_DELIVERY_HEADER, deliveryId)
+                }
                 setBody(
                     ByteArrayContent(
                         bytes = bodyBytes,

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
@@ -31,6 +31,7 @@ data class IndexWebhookConfig(
     val url: String? = null,
     val payloadMode: IndexWebhookPayloadMode = IndexWebhookPayloadMode.RecordingOnly,
     val headers: Map<String, String> = emptyMap(),
+    val signRequests: Boolean = false,
     val saved: Boolean = false,
 ) {
     val isActive: Boolean get() = saved && !url.isNullOrBlank()

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSettingsViewModel.kt
@@ -28,6 +28,7 @@ class IndexWebhookSettingsViewModel(
     private val webhookPreferences: IndexWebhookPreferences,
     private val webhookApi: IndexWebhookApi,
     private val runRepository: IndexWebhookRunRepository,
+    private val signingSecretStorage: IndexWebhookSigningSecretStorage,
 ) : ViewModel() {
 
     private val _gesture = MutableStateFlow<RingGesture?>(null)
@@ -56,6 +57,18 @@ class IndexWebhookSettingsViewModel(
     private val _payloadModeInput = MutableStateFlow(IndexWebhookPayloadMode.RecordingOnly)
     val payloadModeInput = _payloadModeInput.asStateFlow()
 
+    private val _signRequestsInput = MutableStateFlow(false)
+    val signRequestsInput = _signRequestsInput.asStateFlow()
+
+    private val _signingSecretInput = MutableStateFlow("")
+    val signingSecretInput = _signingSecretInput.asStateFlow()
+
+    private val _signingSecretLoading = MutableStateFlow(false)
+    val signingSecretLoading = _signingSecretLoading.asStateFlow()
+
+    private val _saving = MutableStateFlow(false)
+    val saving = _saving.asStateFlow()
+
     private val _testState = MutableStateFlow<WebhookTestState>(WebhookTestState.Idle)
     val testState = _testState.asStateFlow()
 
@@ -75,21 +88,33 @@ class IndexWebhookSettingsViewModel(
         gesture != null && configs[gesture]?.url?.isNotBlank() == true
     }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
+    private var secretLoadId = 0L
+
     fun openDialog(gesture: RingGesture = RingGesture.Hold) {
         val config = webhookPreferences.configFor(gesture)
-        loadDraft(config)
-        _testState.value = WebhookTestState.Idle
         _gesture.value = gesture
+        loadDraft(config, gesture)
+        _testState.value = WebhookTestState.Idle
     }
 
     fun closeDialog() {
+        secretLoadId++
+        _signingSecretInput.value = ""
+        _signingSecretLoading.value = false
         _gesture.value = null
     }
 
     fun removeCurrentGesture() {
         val gesture = _gesture.value ?: return
-        webhookPreferences.clear(gesture)
-        closeDialog()
+        viewModelScope.launch {
+            try {
+                signingSecretStorage.delete(gesture)
+                webhookPreferences.clear(gesture)
+                if (_gesture.value == gesture) closeDialog()
+            } catch (_: Exception) {
+                _testState.value = WebhookTestState.Done(false, "Could not remove webhook")
+            }
+        }
     }
 
     fun updateUrlInput(url: String) {
@@ -120,17 +145,35 @@ class IndexWebhookSettingsViewModel(
         _payloadModeInput.value = mode
     }
 
+    fun updateSignRequests(signRequests: Boolean) {
+        _signRequestsInput.value = signRequests
+    }
+
+    fun updateSigningSecret(secret: String) {
+        _signingSecretInput.value = secret
+    }
+
     fun copyFromOtherGesture() {
         val other = copyableGesture.value ?: return
-        loadDraft(webhookPreferences.configFor(other))
+        loadDraft(webhookPreferences.configFor(other), other)
     }
 
     fun sendTestEvent() {
         val gesture = _gesture.value ?: return
         val url = _urlInput.value.trim().ifBlank { null } ?: return
+        if (_signingSecretLoading.value) return
+        val signRequests = _signRequestsInput.value
+        val signingSecret = _signingSecretInput.value.takeIf { signRequests }
+        if (signRequests && signingSecret.isNullOrBlank()) return
         _testState.value = WebhookTestState.Sending
         viewModelScope.launch {
-            val result = webhookApi.sendTestEvent(gesture, url, draftHeaders())
+            val result = webhookApi.sendTestEvent(
+                gesture = gesture,
+                url = url,
+                headers = draftHeaders(),
+                signRequests = signRequests,
+                signingSecret = signingSecret,
+            )
             _testState.value = WebhookTestState.Done(
                 ok = result.ok,
                 label = "${result.status} · ${result.durationMs} ms",
@@ -141,28 +184,65 @@ class IndexWebhookSettingsViewModel(
     fun save() {
         val gesture = _gesture.value ?: return
         val url = _urlInput.value.trim().ifBlank { null }
-        if (url == null) {
-            webhookPreferences.clear(gesture)
-        } else {
-            webhookPreferences.setConfig(
-                gesture,
-                IndexWebhookConfig(
-                    url = url,
-                    payloadMode = _payloadModeInput.value,
-                    headers = draftHeaders(),
-                    saved = true,
-                ),
-            )
+        if (_signingSecretLoading.value || _saving.value) return
+        val signRequests = _signRequestsInput.value
+        val signingSecret = _signingSecretInput.value
+        if (signRequests && signingSecret.isBlank()) return
+        val payloadMode = _payloadModeInput.value
+        val headers = draftHeaders()
+        _saving.value = true
+        viewModelScope.launch {
+            try {
+                if (url == null) {
+                    signingSecretStorage.delete(gesture)
+                    webhookPreferences.clear(gesture)
+                } else {
+                    if (signingSecret.isNotBlank()) {
+                        signingSecretStorage.save(gesture, signingSecret)
+                    } else {
+                        signingSecretStorage.delete(gesture)
+                    }
+                    webhookPreferences.setConfig(
+                        gesture,
+                        IndexWebhookConfig(
+                            url = url,
+                            payloadMode = payloadMode,
+                            headers = headers,
+                            signRequests = signRequests,
+                            saved = true,
+                        ),
+                    )
+                }
+                if (_gesture.value == gesture) closeDialog()
+            } catch (_: Exception) {
+                _testState.value = WebhookTestState.Done(false, "Could not save webhook")
+            } finally {
+                _saving.value = false
+            }
         }
-        closeDialog()
     }
 
-    private fun loadDraft(config: IndexWebhookConfig) {
+    private fun loadDraft(config: IndexWebhookConfig, secretGesture: RingGesture) {
         _urlInput.value = config.url ?: ""
         _headerInputs.value = config.headers
             .map { WebhookHeaderInput(it.key, it.value) }
             .ifEmpty { listOf(WebhookHeaderInput("", "")) }
         _payloadModeInput.value = config.payloadMode
+        _signRequestsInput.value = config.signRequests
+        _signingSecretInput.value = ""
+        val loadId = ++secretLoadId
+        _signingSecretLoading.value = true
+        viewModelScope.launch {
+            val secret = try {
+                signingSecretStorage.get(secretGesture).orEmpty()
+            } catch (_: Exception) {
+                ""
+            }
+            if (secretLoadId == loadId && _gesture.value != null) {
+                _signingSecretInput.value = secret
+                _signingSecretLoading.value = false
+            }
+        }
     }
 
     /** Drops rows with a blank name; later rows win on duplicate names. */

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSheet.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSheet.kt
@@ -159,6 +159,54 @@ fun IndexWebhookSheet(
             }
 
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                SectionLabel("Headers")
+                headerInputs.forEachIndexed { index, header ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        OutlinedTextField(
+                            value = header.name,
+                            onValueChange = { viewModel.updateHeaderName(index, it) },
+                            singleLine = true,
+                            shape = RoundedCornerShape(8.dp),
+                            textStyle = MaterialTheme.typography.bodyMedium,
+                            placeholder = { Text("Name", style = MaterialTheme.typography.bodyMedium) },
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = dismissKeyboard,
+                            modifier = Modifier.weight(1f),
+                        )
+                        OutlinedTextField(
+                            value = header.value,
+                            onValueChange = { viewModel.updateHeaderValue(index, it) },
+                            singleLine = true,
+                            shape = RoundedCornerShape(8.dp),
+                            textStyle = MaterialTheme.typography.bodyMedium,
+                            placeholder = { Text("Value", style = MaterialTheme.typography.bodyMedium) },
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = dismissKeyboard,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = { viewModel.removeHeader(index) }) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = "Remove header",
+                                tint = colors.onSurfaceVariant,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                }
+                TextButton(
+                    onClick = viewModel::addHeader,
+                    contentPadding = PaddingValues(4.dp),
+                ) {
+                    Text("Add header", style = MaterialTheme.typography.labelLarge)
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 SectionLabel("Security")
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -168,7 +216,7 @@ fun IndexWebhookSheet(
                     Column(modifier = Modifier.weight(1f)) {
                         Text("Sign requests", style = MaterialTheme.typography.bodyLarge)
                         Text(
-                            "Add an HMAC-SHA256 signature your server can verify",
+                            "Add an HMAC-SHA256 signature",
                             style = MaterialTheme.typography.bodySmall,
                             color = colors.onSurfaceVariant,
                         )
@@ -234,54 +282,6 @@ fun IndexWebhookSheet(
                             },
                         )
                     }
-                }
-            }
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                SectionLabel("Headers")
-                headerInputs.forEachIndexed { index, header ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        OutlinedTextField(
-                            value = header.name,
-                            onValueChange = { viewModel.updateHeaderName(index, it) },
-                            singleLine = true,
-                            shape = RoundedCornerShape(8.dp),
-                            textStyle = MaterialTheme.typography.bodyMedium,
-                            placeholder = { Text("Name", style = MaterialTheme.typography.bodyMedium) },
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                            keyboardActions = dismissKeyboard,
-                            modifier = Modifier.weight(1f),
-                        )
-                        OutlinedTextField(
-                            value = header.value,
-                            onValueChange = { viewModel.updateHeaderValue(index, it) },
-                            singleLine = true,
-                            shape = RoundedCornerShape(8.dp),
-                            textStyle = MaterialTheme.typography.bodyMedium,
-                            placeholder = { Text("Value", style = MaterialTheme.typography.bodyMedium) },
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                            keyboardActions = dismissKeyboard,
-                            modifier = Modifier.weight(1f),
-                        )
-                        IconButton(onClick = { viewModel.removeHeader(index) }) {
-                            Icon(
-                                Icons.Default.Close,
-                                contentDescription = "Remove header",
-                                tint = colors.onSurfaceVariant,
-                                modifier = Modifier.size(20.dp),
-                            )
-                        }
-                    }
-                }
-                TextButton(
-                    onClick = viewModel::addHeader,
-                    contentPadding = PaddingValues(4.dp),
-                ) {
-                    Text("Add header", style = MaterialTheme.typography.labelLarge)
                 }
             }
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSheet.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSheet.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Webhook
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,17 +36,24 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coredevices.ring.service.button.RingGesture
@@ -62,6 +71,10 @@ fun IndexWebhookSheet(
     val urlInput by viewModel.urlInput.collectAsState()
     val headerInputs by viewModel.headerInputs.collectAsState()
     val payloadMode by viewModel.payloadModeInput.collectAsState()
+    val signRequests by viewModel.signRequestsInput.collectAsState()
+    val signingSecret by viewModel.signingSecretInput.collectAsState()
+    val signingSecretLoading by viewModel.signingSecretLoading.collectAsState()
+    val saving by viewModel.saving.collectAsState()
     val testState by viewModel.testState.collectAsState()
     val copyable by viewModel.copyableGesture.collectAsState()
     val canRemove by viewModel.canRemove.collectAsState()
@@ -69,6 +82,8 @@ fun IndexWebhookSheet(
     val focusManager = LocalFocusManager.current
     val dismissKeyboard = KeyboardActions(onDone = { focusManager.clearFocus() })
     val colors = IndexTheme.colors
+    var revealSigningSecret by remember(openFor) { mutableStateOf(false) }
+    val signingReady = !signRequests || signingSecret.isNotBlank()
 
     ModalBottomSheet(
         onDismissRequest = viewModel::closeDialog,
@@ -144,6 +159,85 @@ fun IndexWebhookSheet(
             }
 
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                SectionLabel("Security")
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Sign requests", style = MaterialTheme.typography.bodyLarge)
+                        Text(
+                            "Add an HMAC-SHA256 signature your server can verify",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colors.onSurfaceVariant,
+                        )
+                    }
+                    Switch(
+                        checked = signRequests,
+                        onCheckedChange = viewModel::updateSignRequests,
+                        enabled = !signingSecretLoading,
+                    )
+                }
+                if (signRequests) {
+                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        SectionLabel("Signing secret")
+                        OutlinedTextField(
+                            value = signingSecret,
+                            onValueChange = viewModel::updateSigningSecret,
+                            enabled = !signingSecretLoading,
+                            singleLine = true,
+                            shape = RoundedCornerShape(8.dp),
+                            placeholder = {
+                                Text(if (signingSecretLoading) "Loading…" else "Paste a secret")
+                            },
+                            isError = !signingSecretLoading && signingSecret.isBlank(),
+                            visualTransformation = if (revealSigningSecret) {
+                                VisualTransformation.None
+                            } else {
+                                PasswordVisualTransformation()
+                            },
+                            trailingIcon = {
+                                IconButton(
+                                    onClick = { revealSigningSecret = !revealSigningSecret },
+                                    enabled = !signingSecretLoading,
+                                ) {
+                                    Icon(
+                                        if (revealSigningSecret) Icons.Default.VisibilityOff
+                                        else Icons.Default.Visibility,
+                                        contentDescription = if (revealSigningSecret) {
+                                            "Hide signing secret"
+                                        } else {
+                                            "Show signing secret"
+                                        },
+                                    )
+                                }
+                            },
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Password,
+                                imeAction = ImeAction.Done,
+                            ),
+                            keyboardActions = dismissKeyboard,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Text(
+                            if (!signingSecretLoading && signingSecret.isBlank()) {
+                                "A signing secret is required"
+                            } else {
+                                "Use a unique random secret of at least 32 bytes"
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (!signingSecretLoading && signingSecret.isBlank()) {
+                                colors.error
+                            } else {
+                                colors.onSurfaceVariant
+                            },
+                        )
+                    }
+                }
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 SectionLabel("Headers")
                 headerInputs.forEachIndexed { index, header ->
                     Row(
@@ -197,7 +291,8 @@ fun IndexWebhookSheet(
             ) {
                 OutlinedButton(
                     onClick = viewModel::sendTestEvent,
-                    enabled = urlInput.isNotBlank() && testState != WebhookTestState.Sending,
+                    enabled = urlInput.isNotBlank() && signingReady && !signingSecretLoading &&
+                        testState != WebhookTestState.Sending,
                     shape = CircleShape,
                     contentPadding = PaddingValues(horizontal = 20.dp),
                 ) {
@@ -227,11 +322,11 @@ fun IndexWebhookSheet(
 
             Button(
                 onClick = viewModel::save,
-                enabled = urlInput.isNotBlank(),
+                enabled = urlInput.isNotBlank() && signingReady && !signingSecretLoading && !saving,
                 shape = CircleShape,
                 modifier = Modifier.fillMaxWidth().height(48.dp),
             ) {
-                Text("Save")
+                Text(if (saving) "Saving…" else "Save")
             }
 
             if (canRemove) {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigning.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigning.kt
@@ -1,0 +1,76 @@
+package coredevices.ring.external.indexwebhook
+
+import coredevices.ring.service.button.RingGesture
+import coredevices.util.integrations.IntegrationTokenStorage
+
+internal const val WEBHOOK_SIGNATURE_HEADER = "X-Index-Signature"
+internal const val WEBHOOK_TIMESTAMP_HEADER = "X-Index-Timestamp"
+internal const val WEBHOOK_DELIVERY_HEADER = "X-Index-Delivery"
+
+internal val RESERVED_WEBHOOK_HEADERS = setOf(
+    WEBHOOK_AUDIO_SIZE_HEADER,
+    WEBHOOK_TRIGGER_HEADER,
+    WEBHOOK_TEST_HEADER,
+    WEBHOOK_SIGNATURE_HEADER,
+    WEBHOOK_TIMESTAMP_HEADER,
+    WEBHOOK_DELIVERY_HEADER,
+    WEBHOOK_VERSION_HEADER,
+)
+
+internal fun Map<String, String>.withoutReservedWebhookHeaders(): Map<String, String> =
+    filterKeys { name -> RESERVED_WEBHOOK_HEADERS.none { it.equals(name, ignoreCase = true) } }
+
+internal fun buildWebhookSignatureInput(
+    timestamp: Long,
+    deliveryId: String,
+    triggerValue: String,
+    isTest: Boolean,
+    body: ByteArray,
+): ByteArray = buildString {
+    append('v')
+    append(WEBHOOK_VERSION)
+    append('\n')
+    append(timestamp)
+    append('\n')
+    append(deliveryId)
+    append('\n')
+    append(triggerValue)
+    append('\n')
+    append(if (isTest) '1' else '0')
+    append('\n')
+}.encodeToByteArray() + body
+
+internal fun createWebhookSignature(
+    secret: String,
+    timestamp: Long,
+    deliveryId: String,
+    triggerValue: String,
+    isTest: Boolean,
+    body: ByteArray,
+): String {
+    val signature = hmacSha256(
+        key = secret.encodeToByteArray(),
+        message = buildWebhookSignatureInput(timestamp, deliveryId, triggerValue, isTest, body),
+    )
+    return signature.joinToString("") {
+        (it.toInt() and 0xff).toString(16).padStart(2, '0')
+    }
+}
+
+internal expect fun hmacSha256(key: ByteArray, message: ByteArray): ByteArray
+
+class IndexWebhookSigningSecretStorage(
+    private val tokenStorage: IntegrationTokenStorage,
+) {
+    suspend fun get(gesture: RingGesture): String? = tokenStorage.getToken(key(gesture))
+
+    suspend fun save(gesture: RingGesture, secret: String) {
+        tokenStorage.saveToken(key(gesture), secret)
+    }
+
+    suspend fun delete(gesture: RingGesture) {
+        tokenStorage.deleteToken(key(gesture))
+    }
+
+    private fun key(gesture: RingGesture) = "index_webhook_signing_secret_${gesture.name}"
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferencesTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferencesTest.kt
@@ -108,6 +108,7 @@ class IndexWebhookPreferencesTest {
             url = "https://hold.example.com",
             payloadMode = IndexWebhookPayloadMode.TranscriptionOnly,
             headers = mapOf("X-A" to "1"),
+            signRequests = true,
             saved = true,
         )
 
@@ -116,6 +117,18 @@ class IndexWebhookPreferencesTest {
         val reloaded = IndexWebhookPreferences(settings)
         assertEquals(hold, reloaded.configFor(RingGesture.Hold))
         assertEquals(IndexWebhookConfig(), reloaded.configFor(RingGesture.ClickHold))
+    }
+
+    @Test
+    fun existingSerializedConfigsDefaultToUnsigned() {
+        val settings = MapSettings(
+            "index_webhook_config_Hold" to
+                """{"url":"https://example.com/hook","saved":true}""",
+        )
+
+        val config = IndexWebhookPreferences(settings).configFor(RingGesture.Hold)
+
+        assertFalse(config.signRequests)
     }
 
     @Test

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSettingsViewModelTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSettingsViewModelTest.kt
@@ -1,0 +1,182 @@
+package coredevices.ring.external.indexwebhook
+
+import com.russhwolf.settings.MapSettings
+import coredevices.ring.service.button.RingGesture
+import coredevices.util.integrations.IntegrationTokenStorage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IndexWebhookSettingsViewModelTest {
+
+    @Test
+    fun saveStoresOnlyTheSigningFlagInPreferencesAndSecretInSecureStorage() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val fixture = Fixture()
+            fixture.viewModel.openDialog(RingGesture.Hold)
+            advanceUntilIdle()
+
+            fixture.viewModel.updateUrlInput("https://example.com/hook")
+            fixture.viewModel.updateSignRequests(true)
+            fixture.viewModel.updateSigningSecret("  exact secret value  ")
+            fixture.viewModel.save()
+            advanceUntilIdle()
+
+            val config = fixture.preferences.configFor(RingGesture.Hold)
+            assertTrue(config.signRequests)
+            assertEquals("https://example.com/hook", config.url)
+            assertEquals(
+                "  exact secret value  ",
+                fixture.secretStorage.get(RingGesture.Hold),
+            )
+            assertFalse(fixture.settings.keys.any { key ->
+                fixture.settings.getStringOrNull(key)?.contains("exact secret value") == true
+            })
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun copyAndTestEventUseTheOtherGesturesSigningSecret() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val fixture = Fixture()
+            fixture.preferences.setConfig(
+                RingGesture.ClickHold,
+                IndexWebhookConfig(
+                    url = "https://other.example/hook",
+                    signRequests = true,
+                    saved = true,
+                ),
+            )
+            fixture.secretStorage.save(RingGesture.ClickHold, "other-secret")
+
+            fixture.viewModel.openDialog(RingGesture.Hold)
+            advanceUntilIdle()
+            fixture.viewModel.copyFromOtherGesture()
+            advanceUntilIdle()
+
+            assertEquals("https://other.example/hook", fixture.viewModel.urlInput.value)
+            assertTrue(fixture.viewModel.signRequestsInput.value)
+            assertEquals("other-secret", fixture.viewModel.signingSecretInput.value)
+
+            fixture.viewModel.sendTestEvent()
+            advanceUntilIdle()
+
+            assertEquals(
+                TestRequest(
+                    gesture = RingGesture.Hold,
+                    url = "https://other.example/hook",
+                    signRequests = true,
+                    signingSecret = "other-secret",
+                ),
+                fixture.api.lastTestRequest,
+            )
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun removingWebhookAlsoDeletesItsSigningSecret() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val fixture = Fixture()
+            fixture.preferences.setConfig(
+                RingGesture.Hold,
+                IndexWebhookConfig(
+                    url = "https://example.com/hook",
+                    signRequests = true,
+                    saved = true,
+                ),
+            )
+            fixture.secretStorage.save(RingGesture.Hold, "secret")
+
+            fixture.viewModel.openDialog(RingGesture.Hold)
+            advanceUntilIdle()
+            fixture.viewModel.removeCurrentGesture()
+            advanceUntilIdle()
+
+            assertEquals(IndexWebhookConfig(), fixture.preferences.configFor(RingGesture.Hold))
+            assertNull(fixture.secretStorage.get(RingGesture.Hold))
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    private class Fixture {
+        val settings = MapSettings()
+        val preferences = IndexWebhookPreferences(settings)
+        private val tokenStorage = MemoryTokenStorage()
+        val secretStorage = IndexWebhookSigningSecretStorage(tokenStorage)
+        val api = FakeWebhookApi()
+        private val runRepository = IndexWebhookRunRepository(settings)
+        val viewModel = IndexWebhookSettingsViewModel(
+            preferences,
+            api,
+            runRepository,
+            secretStorage,
+        )
+    }
+
+    private data class TestRequest(
+        val gesture: RingGesture,
+        val url: String,
+        val signRequests: Boolean,
+        val signingSecret: String?,
+    )
+
+    private class FakeWebhookApi : IndexWebhookApi {
+        var lastTestRequest: TestRequest? = null
+
+        override fun uploadIfEnabled(
+            samples: ShortArray?,
+            sampleRate: Int,
+            recordingId: String,
+            transcription: String?,
+            recordedAt: Instant,
+            gesture: RingGesture,
+        ) = Unit
+
+        override suspend fun sendTestEvent(
+            gesture: RingGesture,
+            url: String,
+            headers: Map<String, String>,
+            signRequests: Boolean,
+            signingSecret: String?,
+        ): IndexWebhookRunResult {
+            lastTestRequest = TestRequest(gesture, url, signRequests, signingSecret)
+            return IndexWebhookRunResult(true, "200 OK", "test event", 0, 0)
+        }
+    }
+
+    private class MemoryTokenStorage : IntegrationTokenStorage {
+        private val values = mutableMapOf<String, String>()
+
+        override suspend fun saveToken(key: String, token: String) {
+            values[key] = token
+        }
+
+        override suspend fun getToken(key: String): String? = values[key]
+
+        override suspend fun deleteToken(key: String) {
+            values.remove(key)
+        }
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigningTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigningTest.kt
@@ -1,0 +1,134 @@
+package coredevices.ring.external.indexwebhook
+
+import coredevices.ring.service.button.RingGesture
+import coredevices.util.integrations.IntegrationTokenStorage
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class IndexWebhookSigningTest {
+
+    @Test
+    fun hmacSha256MatchesRfc4231TestVector() {
+        val digest = hmacSha256(
+            key = ByteArray(20) { 0x0b },
+            message = "Hi There".encodeToByteArray(),
+        )
+
+        assertEquals(
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
+            digest.toHex(),
+        )
+    }
+
+    @Test
+    fun signatureInputContainsVersionedMetadataThenExactBodyBytes() {
+        val body = byteArrayOf(0, 1, 2, -1)
+
+        val input = buildWebhookSignatureInput(
+            timestamp = 1_700_000_000,
+            deliveryId = "delivery-123",
+            triggerValue = "single-click-hold",
+            isTest = false,
+            body = body,
+        )
+
+        assertContentEquals(
+            "v1\n1700000000\ndelivery-123\nsingle-click-hold\n0\n".encodeToByteArray() + body,
+            input,
+        )
+    }
+
+    @Test
+    fun signatureChangesWhenBodyOrMetadataChanges() {
+        fun signature(body: ByteArray, trigger: String = "single-click-hold") =
+            createWebhookSignature(
+                secret = "0123456789abcdef0123456789abcdef",
+                timestamp = 1_700_000_000,
+                deliveryId = "delivery-123",
+                triggerValue = trigger,
+                isTest = false,
+                body = body,
+            )
+
+        val original = signature(byteArrayOf(1, 2, 3))
+
+        assertNotEquals(original, signature(byteArrayOf(1, 2, 4)))
+        assertNotEquals(original, signature(byteArrayOf(1, 2, 3), "double-click-hold"))
+    }
+
+    @Test
+    fun signatureHeaderValueIsRawLowercaseHex() {
+        val signature = createWebhookSignature(
+            secret = "0123456789abcdef0123456789abcdef",
+            timestamp = 1_700_000_000,
+            deliveryId = "delivery-123",
+            triggerValue = "single-click-hold",
+            isTest = false,
+            body = byteArrayOf(1, 2, 3),
+        )
+
+        assertEquals(64, signature.length)
+        assertTrue(signature.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    @Test
+    fun reservedHeadersCannotBeOverriddenCaseInsensitively() {
+        val headers = mapOf(
+            "Authorization" to "Bearer abc",
+            "x-index-signature" to "forged",
+            "X-INDEX-TIMESTAMP" to "0",
+            "X-Index-Delivery" to "forged",
+            "x-index-webhook-version" to "999",
+            "x-index-trigger" to "forged",
+            "X-Index-Test" to "false",
+            "x-audio-size" to "999",
+        )
+
+        val filtered = headers.withoutReservedWebhookHeaders()
+
+        assertEquals(mapOf("Authorization" to "Bearer abc"), filtered)
+        RESERVED_WEBHOOK_HEADERS.forEach { reserved ->
+            assertFalse(filtered.keys.any { it.equals(reserved, ignoreCase = true) })
+        }
+    }
+
+    @Test
+    fun signingSecretsAreStoredSeparatelyForEachGesture() = runTest {
+        val tokens = MemoryTokenStorage()
+        val storage = IndexWebhookSigningSecretStorage(tokens)
+
+        storage.save(RingGesture.Hold, "hold-secret")
+        storage.save(RingGesture.ClickHold, "click-hold-secret")
+
+        assertEquals("hold-secret", storage.get(RingGesture.Hold))
+        assertEquals("click-hold-secret", storage.get(RingGesture.ClickHold))
+
+        storage.delete(RingGesture.Hold)
+
+        assertEquals(null, storage.get(RingGesture.Hold))
+        assertEquals("click-hold-secret", storage.get(RingGesture.ClickHold))
+    }
+
+    private fun ByteArray.toHex(): String = joinToString("") {
+        (it.toInt() and 0xff).toString(16).padStart(2, '0')
+    }
+
+    private class MemoryTokenStorage : IntegrationTokenStorage {
+        private val values = mutableMapOf<String, String>()
+
+        override suspend fun saveToken(key: String, token: String) {
+            values[key] = token
+        }
+
+        override suspend fun getToken(key: String): String? = values[key]
+
+        override suspend fun deleteToken(key: String) {
+            values.remove(key)
+        }
+    }
+}

--- a/experimental/src/iosMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigning.ios.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSigning.ios.kt
@@ -1,0 +1,28 @@
+package coredevices.ring.external.indexwebhook
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.CCHmac
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.CoreCrypto.kCCHmacAlgSHA256
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun hmacSha256(key: ByteArray, message: ByteArray): ByteArray {
+    val result = ByteArray(CC_SHA256_DIGEST_LENGTH)
+    key.usePinned { keyPinned ->
+        message.usePinned { messagePinned ->
+            result.usePinned { resultPinned ->
+                CCHmac(
+                    kCCHmacAlgSHA256,
+                    keyPinned.addressOf(0),
+                    key.size.toULong(),
+                    messagePinned.addressOf(0),
+                    message.size.toULong(),
+                    resultPinned.addressOf(0),
+                )
+            }
+        }
+    }
+    return result
+}


### PR DESCRIPTION
Index webhooks can now opt into HMAC-SHA256 request signing. Existing webhooks remain unsigned unless the new setting is enabled, so this is backward compatible.

The webhook configuration UI/screen now includes a Security section where users can enable signing and enter a secret. The secret is stored using the existing secure token storage instead of the regular webhook preferences.

Signed requests include:

- `X-Index-Webhook-Version`
- `X-Index-Signature`
- `X-Index-Timestamp`
- `X-Index-Delivery`

The signature covers the webhook version, timestamp, delivery ID, trigger, test status, and exact request body. The webhook API documentation includes the complete verification protocol and a Python example.

## Implementation

- Added the signing controls to the existing webhook screen.
- Added shared signing-input and header logic, with platform-specific HMAC implementations for Android and iOS.
- Stored signing secrets separately using Android Keystore-backed encrypted storage and Apple Keychain.
- Added signature headers when sending regular and test webhook requests.
- Filtered reserved webhook headers from user-defined headers.
- Documented the protocol in `INDEX_WEBHOOK_API.md`.

## Tests

Added focused tests in:

- `IndexWebhookSigningTest.kt`: RFC 4231 vector, signing-input construction, signature formatting, request changes, reserved headers, and per-gesture secrets.
- `IndexWebhookSettingsViewModelTest.kt`: secure secret storage, copied configurations, test events, and secret deletion.
- `IndexWebhookPreferencesTest.kt`: backward compatibility and signed-configuration persistence.

Android build, unit tests, host tests, JVM tests, and lint pass. The app was also installed and tested on a physical Android device.

## Screenshots

### Signing disabled (default state)

<img width="540" height="1212" alt="Screenshot_20260822-215327" src="https://github.com/user-attachments/assets/95a6ae54-a1cb-487a-84b7-c724fd0591bf" />

### Signing enabled, shows secret field

<img width="540" height="1212" alt="Screenshot_20260822-215334" src="https://github.com/user-attachments/assets/55ab7f97-4344-4a4c-a7bc-a3a80f7fb42f" />

Disclosure: This implementation was developed with AI assistance (codex, 5.6-sol-xh). I reviewed the complete diff, iterated on it multiple times to get the UI/UX, documentation, contract right. I tested the Android build on Pixel Fold Pro 9, an my Index 01 device, and reviewed the webhook signing protocol and security behavior. Implemented it on my agentic back-end, and successfully using it in production.