### PR TITLE
Decode merged rapid double clicks so repeated skips stack

### DIFF
--- a/experimental/src/androidMain/kotlin/coredevices/ring/service/RingSync.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/service/RingSync.android.kt
@@ -49,3 +49,25 @@ actual fun onNextTrack() {
     audioManager.dispatchMediaKeyEvent(downEvent)
     audioManager.dispatchMediaKeyEvent(upEvent)
 }
+
+actual fun onPreviousTrack() {
+    val context: Context = KoinPlatform.getKoin().get()
+    val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
+    val eventTime = System.currentTimeMillis()
+    val downEvent = KeyEvent(
+        eventTime,
+        eventTime,
+        KeyEvent.ACTION_DOWN,
+        KeyEvent.KEYCODE_MEDIA_PREVIOUS,
+        0
+    )
+    val upEvent = KeyEvent(
+        eventTime,
+        eventTime,
+        KeyEvent.ACTION_UP,
+        KeyEvent.KEYCODE_MEDIA_PREVIOUS,
+        0
+    )
+    audioManager.dispatchMediaKeyEvent(downEvent)
+    audioManager.dispatchMediaKeyEvent(upEvent)
+}

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexButtonActionHandler.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexButtonActionHandler.kt
@@ -5,6 +5,8 @@ import coredevices.ring.service.button.GestureDestination
 import coredevices.ring.service.button.GestureKind
 import coredevices.ring.service.button.GestureRoutingPreferences
 import coredevices.ring.service.button.RingGesture
+import coredevices.ring.service.button.repeatedDoubleClickCount
+import kotlinx.coroutines.delay
 
 class IndexButtonActionHandler(
     private val gestureRouting: GestureRoutingPreferences,
@@ -12,6 +14,7 @@ class IndexButtonActionHandler(
 ) {
     companion object {
         private val logger = Logger.withTag("IndexButtonActionHandler")
+        private const val REPEAT_DISPATCH_SPACING_MS = 200L
     }
     private val sequenceEvents = sequenceRecorder.sequenceEvents()
 
@@ -19,7 +22,10 @@ class IndexButtonActionHandler(
         sequenceEvents.collect { buttonPresses ->
             val gesture = RingGesture.forSequence(buttonPresses)
                 ?.takeIf { it.kind == GestureKind.Music }
-                ?: return@collect
+            if (gesture == null) {
+                handleRepeatedDoubleClicks(buttonPresses)
+                return@collect
+            }
             when (gestureRouting.destinationFor(gesture)) {
                 GestureDestination.PlayPause -> onPlayPause()
                 GestureDestination.NextTrack -> onNextTrack()
@@ -28,5 +34,21 @@ class IndexButtonActionHandler(
             }
             logger.i("Handled button action for sequence: ${buttonPresses.joinToString(", ") { it.name }}")
         }
+    }
+
+    // Only directional skips repeat safely; play/pause would toggle.
+    private suspend fun handleRepeatedDoubleClicks(buttonPresses: List<ButtonPress>) {
+        val repeats = repeatedDoubleClickCount(buttonPresses)
+        if (repeats == 0) return
+        val action = when (gestureRouting.destinationFor(RingGesture.DoubleClick)) {
+            GestureDestination.NextTrack -> ::onNextTrack
+            GestureDestination.PreviousTrack -> ::onPreviousTrack
+            else -> return
+        }
+        repeat(repeats) {
+            action()
+            delay(REPEAT_DISPATCH_SPACING_MS)
+        }
+        logger.i("Handled $repeats stacked double clicks from ${buttonPresses.size} presses")
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexButtonActionHandler.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexButtonActionHandler.kt
@@ -23,6 +23,7 @@ class IndexButtonActionHandler(
             when (gestureRouting.destinationFor(gesture)) {
                 GestureDestination.PlayPause -> onPlayPause()
                 GestureDestination.NextTrack -> onNextTrack()
+                GestureDestination.PreviousTrack -> onPreviousTrack()
                 else -> return@collect
             }
             logger.i("Handled button action for sequence: ${buttonPresses.joinToString(", ") { it.name }}")

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/RingSync.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/RingSync.kt
@@ -80,6 +80,7 @@ private fun ShortArray.toByteArrayLe(): ByteArray {
 
 expect fun onPlayPause()
 expect fun onNextTrack()
+expect fun onPreviousTrack()
 
 sealed interface RingEvent {
     val ringId: String

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/button/GestureRoutingPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/button/GestureRoutingPreferences.kt
@@ -64,6 +64,7 @@ private const val SANDBOX_PREFIX = "mcp_sandbox:"
 private fun GestureDestination.encode(): String = when (this) {
     GestureDestination.PlayPause -> "play_pause"
     GestureDestination.NextTrack -> "next_track"
+    GestureDestination.PreviousTrack -> "previous_track"
     GestureDestination.IndexAgent -> "index_agent"
     GestureDestination.WebSearch -> "web_search"
     GestureDestination.WebhookOnly -> "webhook_only"
@@ -76,6 +77,7 @@ private fun decodeDestination(raw: String): GestureDestination? = when {
         GestureDestination.McpSandbox(raw.removePrefix(SANDBOX_PREFIX).toLongOrNull())
     raw == "play_pause" -> GestureDestination.PlayPause
     raw == "next_track" -> GestureDestination.NextTrack
+    raw == "previous_track" -> GestureDestination.PreviousTrack
     raw == "index_agent" -> GestureDestination.IndexAgent
     raw == "web_search" -> GestureDestination.WebSearch
     raw == "webhook_only" -> GestureDestination.WebhookOnly

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/button/RingGestureRouting.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/button/RingGestureRouting.kt
@@ -19,6 +19,10 @@ enum class RingGesture(val sequence: List<ButtonPress>, val kind: GestureKind) {
     }
 }
 
+/** Rapid repeated clicks arrive merged into one all-Short record; 2k Shorts (k >= 2) are k double clicks. */
+fun repeatedDoubleClickCount(sequence: List<ButtonPress>): Int =
+    if (sequence.size >= 4 && sequence.all { it == ButtonPress.Short }) sequence.size / 2 else 0
+
 /** Where a gesture sends its input. [Music] destinations are only valid for
  *  [GestureKind.Music] gestures, [Recording] destinations only for [GestureKind.Recording]. */
 sealed interface GestureDestination {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/button/RingGestureRouting.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/button/RingGestureRouting.kt
@@ -27,6 +27,7 @@ sealed interface GestureDestination {
 
     data object PlayPause : Music
     data object NextTrack : Music
+    data object PreviousTrack : Music
     data object IndexAgent : Recording
     data object WebSearch : Recording
     data class McpSandbox(val groupId: Long?) : Recording

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/ButtonSwitchboard.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/ButtonSwitchboard.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SettingsEthernet
 import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Webhook
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -88,6 +89,7 @@ fun destinationsFor(kind: GestureKind, hasSandboxGroups: Boolean): List<GestureD
     GestureKind.Music -> listOf(
         GestureDestination.PlayPause,
         GestureDestination.NextTrack,
+        GestureDestination.PreviousTrack,
         GestureDestination.Nothing,
     )
     GestureKind.Recording -> buildList {
@@ -112,6 +114,7 @@ val GestureDestination.tileLabel: String
     get() = when (this) {
         GestureDestination.PlayPause -> "Play/Pause"
         GestureDestination.NextTrack -> "Next track"
+        GestureDestination.PreviousTrack -> "Rewind"
         GestureDestination.IndexAgent -> "Index agent"
         GestureDestination.WebSearch -> "Web search"
         GestureDestination.WebhookOnly -> "Webhook only"
@@ -123,6 +126,7 @@ private val GestureDestination.optionLabel: String
     get() = when (this) {
         GestureDestination.PlayPause -> "Play or pause music"
         GestureDestination.NextTrack -> "Skip to the next track"
+        GestureDestination.PreviousTrack -> "Rewind, or previous track"
         else -> tileLabel
     }
 
@@ -139,6 +143,7 @@ private val GestureDestination.icon: ImageVector
     get() = when (this) {
         GestureDestination.PlayPause -> Icons.Default.PlayArrow
         GestureDestination.NextTrack -> Icons.Default.SkipNext
+        GestureDestination.PreviousTrack -> Icons.Default.SkipPrevious
         GestureDestination.IndexAgent -> Icons.Default.GraphicEq
         GestureDestination.WebSearch -> Icons.Default.Search
         GestureDestination.WebhookOnly -> Icons.Default.Webhook

--- a/experimental/src/commonTest/kotlin/coredevices/ring/service/button/GestureRoutingTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/service/button/GestureRoutingTest.kt
@@ -49,6 +49,25 @@ class GestureRoutingTest {
     }
 
     @Test
+    fun mergedRapidClicksDecodeAsRepeatedDoubleClicks() {
+        assertEquals(0, repeatedDoubleClickCount(emptyList()))
+        assertEquals(0, repeatedDoubleClickCount(List(1) { ButtonPress.Short }))
+        assertEquals(0, repeatedDoubleClickCount(List(2) { ButtonPress.Short }))
+        assertEquals(0, repeatedDoubleClickCount(List(3) { ButtonPress.Short }))
+        assertEquals(2, repeatedDoubleClickCount(List(4) { ButtonPress.Short }))
+        assertEquals(2, repeatedDoubleClickCount(List(5) { ButtonPress.Short }))
+        assertEquals(3, repeatedDoubleClickCount(List(6) { ButtonPress.Short }))
+        assertEquals(6, repeatedDoubleClickCount(List(12) { ButtonPress.Short }))
+        assertEquals(0, repeatedDoubleClickCount(List(4) { ButtonPress.Long }))
+        assertEquals(
+            0,
+            repeatedDoubleClickCount(
+                listOf(ButtonPress.Short, ButtonPress.Short, ButtonPress.Short, ButtonPress.Long)
+            )
+        )
+    }
+
+    @Test
     fun musicControlModeDisabledMigratesToNothing() {
         val routes = routing(MusicControlMode.Disabled).routes.value
 

--- a/experimental/src/iosMain/kotlin/coredevices/ring/service/RingSync.ios.kt
+++ b/experimental/src/iosMain/kotlin/coredevices/ring/service/RingSync.ios.kt
@@ -10,3 +10,7 @@ actual fun onPlayPause() {
 actual fun onNextTrack() {
     //no-op
 }
+
+actual fun onPreviousTrack() {
+    //no-op
+}


### PR DESCRIPTION
The ring merges rapid repeated presses into one growing record: six quick double clicks arrive as a single twelve-Short sequence, match no gesture, and are silently dropped (logcat-verified). This decodes an all-Short sequence of 2k presses (k >= 2) as k double clicks and repeats the double-click action — directional skip destinations only, since repeating play/pause would toggle it; odd remainders are ignored rather than misfired. Unit test included alongside `GestureRoutingTest`.

Builds on #375 — review the top commit only; I'll rebase once that lands (draft until then).

Field-verified: bursts of three and six double clicks previously produced no action at all; they now produce exactly three and six skips.

Written with AI assistance (Claude); reviewed and hardware-tested by me on a Pixel 10 Pro + Index ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)