### PR TITLE
Index webhook: send Recording-only payloads without waiting for transcription

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
@@ -107,6 +107,10 @@ def receive():
 ## Notes
 
 - Uploads are async and non-blocking — they don't delay the normal recording pipeline
-- Failed uploads are retried on the next recording (no persistent retry queue)
-- The recording is always processed normally (transcription + agent) before the webhook fires
+- **Recording only** fires as soon as the audio is on disk, in parallel with transcription and the
+  agent. The endpoint gets the audio at the earliest moment it exists, and still gets it when
+  transcription fails. **Transcription only** and **Both** wait for the recording to be processed,
+  because processing is what produces the transcription they carry
+- A failed upload is logged and listed under **Recent runs**. There is no retry — not on the next
+  recording, and not when the processing queue retries the same one
 - Audio is the same 16kHz resampled version used for transcription

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
@@ -45,6 +45,20 @@ fun IndexWebhookConfig.sendsFor(destination: GestureDestination.Recording): Bool
     isActive && destination != GestureDestination.Nothing
 
 /**
+ * Whether the webhook can be delivered before the recording is processed.
+ *
+ * [IndexWebhookPayloadMode.RecordingOnly] carries nothing that processing produces, and the audio
+ * is already written to disk before processing starts — so waiting for transcription and the agent
+ * only delays the endpoint, and loses the delivery outright when transcription fails. The other two
+ * modes carry the transcription, which is precisely what processing writes.
+ *
+ * Typed input has no audio ([hasAudio] false), so nothing can go early: a recording-only webhook has
+ * nothing at all to deliver, and the other modes still wait for the transcription.
+ */
+fun IndexWebhookPayloadMode.sendsBeforeProcessing(hasAudio: Boolean): Boolean =
+    this == IndexWebhookPayloadMode.RecordingOnly && hasAudio
+
+/**
  * Stores one [IndexWebhookConfig] per recording gesture.
  */
 class IndexWebhookPreferences(private val settings: Settings) {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/IndexWebhookUploadRecordingOperation.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/recordings/button/IndexWebhookUploadRecordingOperation.kt
@@ -6,9 +6,12 @@ import coredevices.indexai.database.dao.RecordingEntryDao
 import coredevices.ring.external.indexwebhook.IndexWebhookApi
 import coredevices.ring.external.indexwebhook.IndexWebhookPayloadMode
 import coredevices.ring.external.indexwebhook.IndexWebhookPreferences
+import coredevices.ring.external.indexwebhook.sendsBeforeProcessing
+import coredevices.ring.service.RecordingBackgroundScope
 import coredevices.ring.service.button.RingGesture
 import coredevices.ring.service.recordings.RecordingProcessingQueue
 import coredevices.ring.storage.RecordingStorage
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.io.buffered
@@ -18,11 +21,18 @@ import org.koin.core.component.inject
 import kotlin.time.Clock
 
 /**
- * Decorator that uploads recording data to a user-configured webhook endpoint
- * after the inner operation (transcription + agent processing) completes.
+ * Decorator that uploads recording data to a user-configured webhook endpoint.
  *
  * Based on payload mode, sends audio, transcription text, or both.
  * Uses the same PCM→M4A encoding pipeline as the original Vermillion integration.
+ *
+ * **When it fires depends on the payload mode.** A mode that carries the transcription has to wait
+ * for the inner operation, because that is what writes the transcription it will read. A
+ * [IndexWebhookPayloadMode.RecordingOnly] webhook never reads it: the audio is already fully
+ * written on disk before this operation starts, so waiting buys the endpoint nothing and costs it
+ * the whole transcription + agent turnaround. So that mode sends straight away, in parallel with
+ * the inner operation, and — because it no longer sits after it — still delivers the audio when
+ * transcription fails outright.
  */
 class IndexWebhookUploadRecordingOperation(
     private val webhookApi: IndexWebhookApi,
@@ -42,13 +52,35 @@ class IndexWebhookUploadRecordingOperation(
 
     private val recordingEntryDao: RecordingEntryDao by inject()
     private val localRecordingDao: LocalRecordingDao by inject()
+    private val backgroundScope: RecordingBackgroundScope by inject()
 
     override suspend fun run(handle: RecordingProcessingQueue.TaskHandle?) {
-        // Run the inner operation first (transcription + agent processing)
+        // Read the mode once. Settings are live, so re-reading it after the inner operation could
+        // pick a different branch from the one that built the payload.
+        val payloadMode = webhookPreferences.configFor(gesture).payloadMode
+        val sendEarly = payloadMode.sendsBeforeProcessing(hasAudio = fileId != null)
+
+        if (sendEarly) {
+            // The long-lived background scope, not the queue's: a slow upload must not hold the
+            // processing slot, and the queue cancelling this task must not cancel the delivery.
+            backgroundScope.launch {
+                try {
+                    send(payloadMode)
+                } catch (e: Exception) {
+                    // The webhook is an add-on. It may never be the reason a recording fails.
+                    logger.e(e) { "Error sending early webhook for recording $fileId" }
+                }
+            }
+        }
+
         decorated.run(handle)
 
+        // Anything carrying the transcription has to wait for the inner operation to write it.
+        if (!sendEarly) send(payloadMode)
+    }
+
+    private suspend fun send(payloadMode: IndexWebhookPayloadMode) {
         val sendKey = fileId ?: "text-$recordingId"
-        val payloadMode = webhookPreferences.configFor(gesture).payloadMode
         // Typed input has no audio, so a recording-only webhook has nothing to deliver.
         if (fileId == null && payloadMode == IndexWebhookPayloadMode.RecordingOnly) return
 

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSendDecisionTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSendDecisionTest.kt
@@ -46,6 +46,24 @@ class IndexWebhookSendDecisionTest {
     }
 
     @Test
+    fun aRecordingOnlyWebhookDoesNotWaitForProcessing() {
+        assertTrue(IndexWebhookPayloadMode.RecordingOnly.sendsBeforeProcessing(hasAudio = true))
+    }
+
+    @Test
+    fun anythingCarryingTheTranscriptionWaitsForIt() {
+        assertFalse(IndexWebhookPayloadMode.TranscriptionOnly.sendsBeforeProcessing(hasAudio = true))
+        assertFalse(IndexWebhookPayloadMode.Both.sendsBeforeProcessing(hasAudio = true))
+    }
+
+    @Test
+    fun typedInputHasNoAudioToSendEarly() {
+        IndexWebhookPayloadMode.entries.forEach {
+            assertFalse(it.sendsBeforeProcessing(hasAudio = false), "$it sent early with no audio")
+        }
+    }
+
+    @Test
     fun triggerHeaderValuesAreStable() {
         assertEquals("single-click-hold", RingGesture.Hold.webhookTriggerValue)
         assertEquals("double-click-hold", RingGesture.ClickHold.webhookTriggerValue)


### PR DESCRIPTION
PR description written manually, targeting human consumption. Code changes driven by Claude, I reviewed the change which seemed small enough and looked correct.

Today, the Index 01 webhook is called **after** transcription + agent turn. 

I've been experimenting with Index 01 and building integrations. I find the in-app agent too limiting so I'm hosting my own, and I find that the Wispr Flow transcription doesn't work well (I speak French + English, also Wispr Flow doesn't have any context for the capabilities of my agent).

So I've built for myself a webhook endpoint that takes in the audio, processes it and runs an agent loop. Great! However, the **latency is pretty bad**, in part because I need to wait for the default transcription (which I don't use) as well as the local agent work. Even worst: if local / cloud transcription fails, the **webhook is never called**.

Ideally I'd have settings to disable transcription + local agent entirely, and just send everything to the webhook. 

One small step that avoids this bigger refactoring while also looking reasonable to me: **when a webhook is registered as "recording only", kick off the webhook upload as soon as the audio file is available**, without waiting for transcription or agent turns.

# Notes from Claude

- `sentRecordingIds` is now marked on the first attempt even when that attempt's *recording* later fails, so a queue retry of the same recording no longer re-sends. That is the one-delivery-per-recording rule the set exists for; a double send was previously reachable only because the first attempt never got as far as the upload.
- corrected a line in the docs that is not true and does not appear to ever have been: _Failed uploads are retried on the next recording (no persistent retry queue)_
- `IndexWebhookApi.uploadIfEnabled` is a bare `scope.launch` that records the failure into the run history and stops. There is no retry anywhere in the `indexwebhook` package (`grep -ri 'retry\|retried\|resend'` finds nothing outside the doc). Happy to split this into its own PR if you would rather keep them separate.