### PR TITLE
Adjust image color quantization to better match colors and use a more realistic palette

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/imaging/ImageEncoder.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/imaging/ImageEncoder.kt
@@ -2,14 +2,15 @@ package io.rebble.libpebblecommon.imaging
 
 /**
  * Encodes an ARGB image as the watch's 4-bpp palettized [EncodedImage]: choose a 16-colour palette
- * by median cut over the watch's 64-colour (GColor8) space, Floyd–Steinberg dither to that palette,
- * and pack two 4-bit indices per byte (even x = high nibble, matching the firmware).
+ * by median cut over the watch's 64 screen colors, Floyd–Steinberg dither to that palette, and
+ * pack two 4-bit indices per byte (even x = high nibble, matching the firmware).
  *
  * Transparency is binary, and costs a palette slot when present. The watch only skips these
  * pixels when it draws with `GCompOpSet`; under the default `GCompOpAssign` they come out black.
  *
- * Pixels are matched against what the panel actually shows (see ScreenColors.kt), not the nominal
- * 0/85/170/255 the GColor8 bits suggest. The bytes on the wire are still GColor8 codes.
+ * Both the palette and the per-pixel match are decided against what the panel actually shows (see
+ * ScreenColors.kt), not the nominal 0/85/170/255 the GColor8 bits suggest. The bytes on the wire
+ * are still GColor8 codes.
  */
 object ImageEncoder {
     private const val MAX_COLORS = 16
@@ -22,22 +23,20 @@ object ImageEncoder {
 
     private fun alphaOf(argb: Int): Int = (argb ushr 24) and 0xFF
 
-    // 8-bit channel (0..255) -> 2-bit GColor8 channel (0..3).
-    private fun quant2(v: Int): Int = (v.coerceIn(0, 255) * 3 + 127) / 255
-    private fun gcolor8(r: Int, g: Int, b: Int): Int = (0x3 shl 6) or (r shl 4) or (g shl 2) or b
+    // Screen color index (0..63) -> the GColor8 byte sent to the watch, always fully opaque.
+    private fun gcolor8(code: Int): Int = 0xC0 or code
 
-    private class Color(val r: Int, val g: Int, val b: Int, val count: Int)
+    private class Entry(val code: Int, val count: Int)
 
     /** Encodes an ARGB8888 pixel array (row-major, [width] * [height]). */
     fun encode(argb: IntArray, width: Int, height: Int): EncodedImage {
         val hasTransparency = argb.any { alphaOf(it) < OPAQUE_ALPHA }
         val colors = medianCutPalette(argb, if (hasTransparency) MAX_COLORS - 1 else MAX_COLORS)
-        val palR = IntArray(colors.size) { SCREEN_R[colors[it] and 0x3F] }
-        val palG = IntArray(colors.size) { SCREEN_G[colors[it] and 0x3F] }
-        val palB = IntArray(colors.size) { SCREEN_B[colors[it] and 0x3F] }
+        val palR = IntArray(colors.size) { SCREEN_R[colors[it]] }
+        val palG = IntArray(colors.size) { SCREEN_G[colors[it]] }
+        val palB = IntArray(colors.size) { SCREEN_B[colors[it]] }
         // Past the colours, so `nearest` can never land an opaque black pixel on it.
         val transparentIdx = colors.size
-        val palette = if (hasTransparency) colors + TRANSPARENT else colors
 
         val stride = (width + 1) / 2
         val pixels = UByteArray(stride * height)
@@ -71,7 +70,9 @@ object ImageEncoder {
             val tmp = curErr; curErr = nextErr; nextErr = tmp
             nextErr.fill(0f)
         }
-        val paletteBytes = UByteArray(palette.size) { palette[it].toUByte() }
+        val paletteBytes = UByteArray(if (hasTransparency) colors.size + 1 else colors.size) {
+            if (it == transparentIdx) TRANSPARENT.toUByte() else gcolor8(colors[it]).toUByte()
+        }
         return EncodedImage(width, height, paletteBytes, pixels)
     }
 
@@ -85,44 +86,61 @@ object ImageEncoder {
         }
     }
 
-    // Median cut over the GColor8-reduced histogram of the opaque pixels. Returns up to
-    // [maxColors] distinct GColor8 palette bytes. Box choice and split point are weighted by pixel
+    // Median cut over the screen colors the image's opaque pixels land on. Returns up to
+    // [maxColors] distinct screen color indices. Box choice and split point are weighted by pixel
     // count, so a large flat region doesn't lose a palette slot to a handful of stray pixels.
     private fun medianCutPalette(argb: IntArray, maxColors: Int): List<Int> {
         val counts = HashMap<Int, Int>()
         for (p in argb) {
             if (alphaOf(p) < OPAQUE_ALPHA) continue
-            val key = (quant2((p shr 16) and 0xFF) shl 4) or
-                (quant2((p shr 8) and 0xFF) shl 2) or quant2(p and 0xFF)
-            counts[key] = (counts[key] ?: 0) + 1
+            val code = nearestScreenColor((p shr 16) and 0xFF, (p shr 8) and 0xFF, p and 0xFF)
+            counts[code] = (counts[code] ?: 0) + 1
         }
-        val initial = counts.entries.map {
-            Color((it.key shr 4) and 0x3, (it.key shr 2) and 0x3, it.key and 0x3, it.value)
-        }.toMutableList()
+        val initial = counts.entries.map { Entry(it.key, it.value) }.toMutableList()
         val boxes = mutableListOf(initial)
         while (boxes.size < maxColors) {
             val bi = boxes.indices.filter { boxes[it].size > 1 }
-                .maxByOrNull { spread(boxes[it]) * population(boxes[it]) } ?: break
+                .maxByOrNull { spread(boxes[it]).toLong() * population(boxes[it]) } ?: break
             val box = boxes[bi]
             val axis = longestAxis(box)
-            box.sortBy { when (axis) { 0 -> it.r; 1 -> it.g; else -> it.b } }
+            box.sortBy { channel(it.code, axis) }
             val mid = weightedMedian(box)
             boxes[bi] = box.subList(0, mid).toMutableList()
             boxes.add(box.subList(mid, box.size).toMutableList())
         }
         return boxes.filter { it.isNotEmpty() }.map { box ->
-            var sr = 0L; var sg = 0L; var sb = 0L; var sn = 0L
-            for (c in box) { sr += c.r.toLong() * c.count; sg += c.g.toLong() * c.count; sb += c.b.toLong() * c.count; sn += c.count }
-            gcolor8(round(sr, sn), round(sg, sn), round(sb, sn))
-        }.distinct().ifEmpty { listOf(gcolor8(0, 0, 0)) }
+            // Screen colors can't be averaged into a new entry the way nominal 2-bit components
+            // could, so take the one nearest the box's count-weighted centroid.
+            var sumR = 0L
+            var sumG = 0L
+            var sumB = 0L
+            var totalCount = 0L
+            for (entry in box) {
+                sumR += SCREEN_R[entry.code].toLong() * entry.count
+                sumG += SCREEN_G[entry.code].toLong() * entry.count
+                sumB += SCREEN_B[entry.code].toLong() * entry.count
+                totalCount += entry.count
+            }
+            nearestScreenColor(
+                round(sumR, totalCount),
+                round(sumG, totalCount),
+                round(sumB, totalCount),
+            )
+        }.distinct().ifEmpty { listOf(nearestScreenColor(0, 0, 0)) }
     }
 
     private fun round(sum: Long, count: Long): Int = ((sum * 2 + count) / (count * 2)).toInt()
 
-    private fun population(box: List<Color>): Long = box.sumOf { it.count.toLong() }
+    private fun channel(code: Int, axis: Int): Int = when (axis) {
+        0 -> SCREEN_R[code]
+        1 -> SCREEN_G[code]
+        else -> SCREEN_B[code]
+    }
+
+    private fun population(box: List<Entry>): Long = box.sumOf { it.count.toLong() }
 
     // Split index that puts half the box's pixels either side, keeping both halves non-empty.
-    private fun weightedMedian(box: List<Color>): Int {
+    private fun weightedMedian(box: List<Entry>): Int {
         val half = population(box) / 2
         var acc = 0L
         for (i in box.indices) {
@@ -132,25 +150,29 @@ object ImageEncoder {
         return box.size - 1
     }
 
-    private fun spread(box: List<Color>): Int {
-        var rl = 3; var rh = 0; var gl = 3; var gh = 0; var bl = 3; var bh = 0
-        for (c in box) {
-            if (c.r < rl) rl = c.r; if (c.r > rh) rh = c.r
-            if (c.g < gl) gl = c.g; if (c.g > gh) gh = c.g
-            if (c.b < bl) bl = c.b; if (c.b > bh) bh = c.b
+    // Side lengths of the box's bounding cuboid, one per RGB channel, in screen colors.
+    private fun extents(box: List<Entry>): IntArray {
+        val lowest = intArrayOf(255, 255, 255)
+        val highest = intArrayOf(0, 0, 0)
+        for (entry in box) {
+            for (axis in 0..2) {
+                val value = channel(entry.code, axis)
+                if (value < lowest[axis]) lowest[axis] = value
+                if (value > highest[axis]) highest[axis] = value
+            }
         }
-        return maxOf(rh - rl, gh - gl, bh - bl)
+        return IntArray(3) { highest[it] - lowest[it] }
     }
 
-    private fun longestAxis(box: List<Color>): Int {
-        var rl = 3; var rh = 0; var gl = 3; var gh = 0; var bl = 3; var bh = 0
-        for (c in box) {
-            if (c.r < rl) rl = c.r; if (c.r > rh) rh = c.r
-            if (c.g < gl) gl = c.g; if (c.g > gh) gh = c.g
-            if (c.b < bl) bl = c.b; if (c.b > bh) bh = c.b
+    private fun spread(box: List<Entry>): Int = extents(box).max()
+
+    private fun longestAxis(box: List<Entry>): Int {
+        val extent = extents(box)
+        return when {
+            extent[0] >= extent[1] && extent[0] >= extent[2] -> 0
+            extent[1] >= extent[2] -> 1
+            else -> 2
         }
-        val dr = rh - rl; val dg = gh - gl; val db = bh - bl
-        return if (dr >= dg && dr >= db) 0 else if (dg >= db) 1 else 2
     }
 
     private fun diffuse(err: FloatArray, x: Int, r: Float, g: Float, b: Float, w: Float) {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/imaging/ImageEncoder.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/imaging/ImageEncoder.kt
@@ -7,6 +7,9 @@ package io.rebble.libpebblecommon.imaging
  *
  * Transparency is binary, and costs a palette slot when present. The watch only skips these
  * pixels when it draws with `GCompOpSet`; under the default `GCompOpAssign` they come out black.
+ *
+ * Pixels are matched against what the panel actually shows (see ScreenColors.kt), not the nominal
+ * 0/85/170/255 the GColor8 bits suggest. The bytes on the wire are still GColor8 codes.
  */
 object ImageEncoder {
     private const val MAX_COLORS = 16
@@ -19,9 +22,8 @@ object ImageEncoder {
 
     private fun alphaOf(argb: Int): Int = (argb ushr 24) and 0xFF
 
-    // 8-bit channel (0..255) -> 2-bit GColor8 channel (0..3), rounded to nearest of 0/85/170/255.
+    // 8-bit channel (0..255) -> 2-bit GColor8 channel (0..3).
     private fun quant2(v: Int): Int = (v.coerceIn(0, 255) * 3 + 127) / 255
-    private fun expand2(c: Int): Int = c * 85
     private fun gcolor8(r: Int, g: Int, b: Int): Int = (0x3 shl 6) or (r shl 4) or (g shl 2) or b
 
     private class Color(val r: Int, val g: Int, val b: Int, val count: Int)
@@ -30,9 +32,9 @@ object ImageEncoder {
     fun encode(argb: IntArray, width: Int, height: Int): EncodedImage {
         val hasTransparency = argb.any { alphaOf(it) < OPAQUE_ALPHA }
         val colors = medianCutPalette(argb, if (hasTransparency) MAX_COLORS - 1 else MAX_COLORS)
-        val palR = IntArray(colors.size) { expand2((colors[it] shr 4) and 0x3) }
-        val palG = IntArray(colors.size) { expand2((colors[it] shr 2) and 0x3) }
-        val palB = IntArray(colors.size) { expand2(colors[it] and 0x3) }
+        val palR = IntArray(colors.size) { SCREEN_R[colors[it] and 0x3F] }
+        val palG = IntArray(colors.size) { SCREEN_G[colors[it] and 0x3F] }
+        val palB = IntArray(colors.size) { SCREEN_B[colors[it] and 0x3F] }
         // Past the colours, so `nearest` can never land an opaque black pixel on it.
         val transparentIdx = colors.size
         val palette = if (hasTransparency) colors + TRANSPARENT else colors

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/imaging/ScreenColors.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/imaging/ScreenColors.kt
@@ -1,0 +1,70 @@
+package io.rebble.libpebblecommon.imaging
+
+/**
+ * What the watch's 64 GColor8 codes actually look like on screen.
+ *
+ * The encoder used to assume each 2-bit channel lands on 0/85/170/255 in sRGB. A reflective panel
+ * does not behave that way: its channel steps are uneven and its primaries bleed into one another,
+ * so matching against the nominal values picks codes the screen never shows and washes every image
+ * out.
+ *
+ * Measured on a Pebble Time 2 in sunlight, indexed by the low six bits of the GColor8 code
+ * (0xC0..0xFF), packed 0xRRGGBB.
+ */
+private val MEASURED_PT2 = intArrayOf(
+    0x1E191F, 0x1B2D43, 0x0F3C5B, 0x00476D,
+    0x384F3D, 0x345856, 0x2E5E68, 0x266577,
+    0x4A6D4F, 0x467263, 0x407973, 0x3C7D81,
+    0x55825B, 0x51866C, 0x4C897A, 0x498C85,
+
+    0x4D2A30, 0x4D374C, 0x494261, 0x464B71,
+    0x5B5444, 0x595B5A, 0x56636C, 0x52677A,
+    0x666F54, 0x637366, 0x607976, 0x5C7D82,
+    0x6C825E, 0x69856E, 0x68887B, 0x648B86,
+
+    0x69343C, 0x683E52, 0x644765, 0x615074,
+    0x71574A, 0x6D5D5E, 0x6D636E, 0x69687A,
+    0x7A7057, 0x777568, 0x737977, 0x727D83,
+    0x7D8061, 0x7B846F, 0x77877C, 0x758987,
+
+    0x7B3A42, 0x7A4358, 0x784B68, 0x755374,
+    0x815A50, 0x7E6060, 0x7C656F, 0x7B6A7C,
+    0x856F59, 0x86756B, 0x847A79, 0x817F84,
+    0x8B8265, 0x8A8572, 0x86887D, 0x848A88,
+)
+
+private fun channel(packed: Int, shift: Int) = (packed shr shift) and 0xFF
+
+// The table is indexed by (r shl 4) or (g shl 2) or b, so the panel's own black and white are the
+// first and last entries. In sunlight the screen spans about a fifth of sRGB's range, and a viewer
+// adapts to that, so the palette is chosen against colors normalized to those endpoints: what
+// should steer the choice is the shape of the correction, not the dimming.
+private fun normalize(shift: Int): IntArray {
+    val black = channel(MEASURED_PT2.first(), shift)
+    val white = channel(MEASURED_PT2.last(), shift)
+    return IntArray(MEASURED_PT2.size) {
+        (((channel(MEASURED_PT2[it], shift) - black) * 255) / (white - black)).coerceIn(0, 255)
+    }
+}
+
+/** Screen colors normalized to the panel's black and white, one array per channel. */
+internal val SCREEN_R = normalize(16)
+internal val SCREEN_G = normalize(8)
+internal val SCREEN_B = normalize(0)
+
+/** Index of the screen color closest to the given sRGB value. */
+internal fun nearestScreenColor(r: Int, g: Int, b: Int): Int {
+    var best = 0
+    var bestDistanceSq = Int.MAX_VALUE
+    for (i in SCREEN_R.indices) {
+        val dr = r - SCREEN_R[i]
+        val dg = g - SCREEN_G[i]
+        val db = b - SCREEN_B[i]
+        val distanceSq = dr * dr + dg * dg + db * db
+        if (distanceSq < bestDistanceSq) {
+            bestDistanceSq = distanceSq
+            best = i
+        }
+    }
+    return best
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/imaging/ImageEncoderTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/imaging/ImageEncoderTest.kt
@@ -100,6 +100,19 @@ internal class ImageEncoderTest {
     }
 
     @Test
+    fun matchesAgainstScreenColors() {
+        // Cross-check against an independent implementation of the same median cut over the
+        // measured screen colors: a port that silently fell back to nominal matching, or got the
+        // normalization wrong, would choose a different set.
+        val art = ImageEncoder.encode(gradient(64, 64), 64, 64)
+        val expected = listOf(
+            0xC1, 0xE1, 0xD8, 0xC5, 0xD1, 0xF0, 0xE8, 0xC8,
+            0xD2, 0xD5, 0xF4, 0xDC, 0xC6, 0xC2, 0xC9, 0xF1,
+        ).map { it.toUByte() }.toSet()
+        assertEquals(expected, art.palette.toSet())
+    }
+
+    @Test
     fun evenPixelIsHighNibble() {
         // 2x1: x=0 black, x=1 white. Black is GColor8 0xC0, white 0xFF.
         val art = ImageEncoder.encode(intArrayOf(argb(0, 0, 0), argb(255, 255, 255)), 2, 1)

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/imaging/ScreenColorsTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/imaging/ScreenColorsTest.kt
@@ -1,0 +1,22 @@
+package io.rebble.libpebblecommon.imaging
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ScreenColorsTest {
+    @Test
+    fun panelBlackAndWhiteNormalizeToTheEndsOfTheRange() {
+        assertEquals(listOf(0, 0, 0), listOf(SCREEN_R[0], SCREEN_G[0], SCREEN_B[0]))
+        assertEquals(listOf(255, 255, 255), listOf(SCREEN_R[63], SCREEN_G[63], SCREEN_B[63]))
+        assertEquals(0, nearestScreenColor(0, 0, 0))
+        assertEquals(63, nearestScreenColor(255, 255, 255))
+    }
+
+    @Test
+    fun saturatedColorsMatchAwayFromTheirNominalCode() {
+        // The panel's red is far dimmer than sRGB's, so full red is nearer 0xE0 than the 0xF0 its
+        // 2-bit quantisation would pick. Matching on nominal values is what washed images out.
+        assertEquals(0x20, nearestScreenColor(255, 0, 0))
+        assertEquals(0x15, nearestScreenColor(128, 128, 128))
+    }
+}


### PR DESCRIPTION
The new notification pictures feature is neat but the pictures appear pretty low-contrast, and not all colors match the on-screen color well.

I tried quiite a few different things, which I'll document in a separate issue, but one of them was improving the color matching logic to consider distance to the palette considering all channels, rather than taking the distance on each channel individually.

Other is perhaps more controversial, which is swapping the palette for comparison to one I measured a while back. This involved taking dozens of pictures of a Time 2 (and PTS but that's unrelated) under various lighting conditions with a DSLR, next to a color calibration grid (SpyderCheckr iirc), and then applying correction in darktable, before sampling the color grid off the device. It's a bit tricky to dial in, especially considering reflective screen and variability of contrast, but I made this out of it: https://fgl.ave.zone/pebblecolors.html#pt2sunlight

It might benefit from a separate measurement for time round, which I'll do when I get mine (assuming there's sunshine hours left in the year).

---

On device (also with Bayer 8x8 in this case):

<img width="3871" height="2302" alt="PXL_20260829_100345224" src="https://github.com/user-attachments/assets/fc73e4cc-4fe5-4d26-86b1-3715ad002a6d" />

---

Written with Claude Opus 5 but I can understand & hopefully explain the logic :) I'd normally clean up the code some more but the previous state already had claudisms so I kept the new claudisms added too, let me know if you prefer it cleaned.

---

Demo: https://fgl.ave.zone/image-recolor-demo/

Some screenshots from it (note that these are emulating the actual screen colors, try toggling bottom left switch):

Top left is current, bottom right is proposed. Do note that the colors are emulating my measured screen values, if using the demo tool yourself you can toggle that on bottom left.

<img width="1855" height="898" alt="Screenshot 2026-08-29 at 17-34-00 Palette _ matching comparison" src="https://github.com/user-attachments/assets/765092f8-a5a8-411f-a24c-6f8302abb0b3" />
<img width="1855" height="898" alt="Screenshot 2026-08-29 at 17-33-43 Palette _ matching comparison" src="https://github.com/user-attachments/assets/19172d16-a4ba-4ac2-8c86-2dc4a5d3d48a" />
<img width="1855" height="898" alt="Screenshot 2026-08-29 at 17-33-34 Palette _ matching comparison" src="https://github.com/user-attachments/assets/4bf89037-ad90-4e59-8c89-de3f0eaa7e19" />
<img width="1855" height="898" alt="Screenshot 2026-08-29 at 17-33-21 Palette _ matching comparison" src="https://github.com/user-attachments/assets/a0ac55bd-ef50-4e4b-a263-6f2f3bfd41db" />
<img width="1855" height="898" alt="Screenshot 2026-08-29 at 17-32-41 Palette _ matching comparison" src="https://github.com/user-attachments/assets/9b202091-f7e7-4cd5-8a02-710d225461c6" />
