### PR TITLE
Fix weather records for non-ASCII location names

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WeatherAppEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WeatherAppEntity.kt
@@ -139,6 +139,12 @@ private fun Double?.toCoordE2(): Short =
     this?.let { (it * 100).roundToInt().coerceIn(Short.MIN_VALUE + 1, Short.MAX_VALUE.toInt()).toShort() }
         ?: WEATHER_V4_COORD_UNKNOWN
 
+private fun serializedWeatherStringsLength(locationName: String, forecastShort: String): UShort =
+    (
+        locationName.encodeToByteArray().size + UShort.SIZE_BYTES +
+            forecastShort.encodeToByteArray().size + UShort.SIZE_BYTES
+    ).toUShort()
+
 class WeatherAppBlobRecord(
     version: UByte = 3u,
     currentTemp: Short,
@@ -163,7 +169,7 @@ class WeatherAppBlobRecord(
     val tomorrowLowTemp = SShort(m, tomorrowLowTemp, endianness = Endian.Little)
     val lastUpdateTimeUtc = SUInt(m, lastUpdateTimeUtc, endianness = Endian.Little)
     val isCurrentLocation = SBoolean(m, isCurrentLocation)
-    val allStringsLength = SUShort(m, (locationName.length + 2 + forecastShort.length + 2).toUShort(), endianness = Endian.Little)
+    val allStringsLength = SUShort(m, serializedWeatherStringsLength(locationName, forecastShort), endianness = Endian.Little)
     val locationName = SLongString(m, locationName, endianness = Endian.Little)
     val forecastShort = SLongString(m, forecastShort, endianness = Endian.Little)
 }
@@ -356,7 +362,7 @@ class WeatherAppBlobRecordV4(
     val tomorrowHourlyTemp = SBytes(m, WEATHER_DB_HOURLY_COUNT, tomorrowHourlyTemp.toUByteArray(), endianness = Endian.Unspecified)
 
     // --- variable-length trailing strings (MUST stay last) ---
-    val allStringsLength = SUShort(m, (locationName.length + 2 + forecastShort.length + 2).toUShort(), endianness = Endian.Little)
+    val allStringsLength = SUShort(m, serializedWeatherStringsLength(locationName, forecastShort), endianness = Endian.Little)
     val locationName = SLongString(m, locationName, endianness = Endian.Little)
     val forecastShort = SLongString(m, forecastShort, endianness = Endian.Little)
 }

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/WeatherAppBlobRecordTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/WeatherAppBlobRecordTest.kt
@@ -1,0 +1,46 @@
+package io.rebble.libpebblecommon.database.entity
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class WeatherAppBlobRecordTest {
+
+    @Test
+    fun trailingStringLengthMatchesSerializedBytes() {
+        val cases = listOf(
+            "" to "",
+            "Prague" to "Overcast",
+            "České Budějovice" to "Overcast",
+            "München" to "Déšť",
+            "東京" to "雷雨 🌧️",
+            "Cafe\u0301" to "Café",
+        )
+
+        cases.forEach { (locationName, forecastShort) ->
+            val record = weatherRecord(locationName, forecastShort)
+            val serializedStringsSize =
+                record.locationName.toBytes().size + record.forecastShort.toBytes().size
+
+            assertEquals(
+                serializedStringsSize,
+                record.allStringsLength.get().toInt(),
+                "locationName=$locationName, forecastShort=$forecastShort",
+            )
+        }
+    }
+
+    private fun weatherRecord(locationName: String, forecastShort: String) =
+        WeatherAppBlobRecord(
+            currentTemp = 20,
+            currentWeatherType = 1u,
+            todayHighTemp = 26,
+            todayLowTemp = 13,
+            tomorrowWeatherType = 1u,
+            tomorrowHighTemp = 26,
+            tomorrowLowTemp = 15,
+            lastUpdateTimeUtc = 0u,
+            isCurrentLocation = false,
+            locationName = locationName,
+            forecastShort = forecastShort,
+        )
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/WeatherAppBlobRecordV4Test.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/WeatherAppBlobRecordV4Test.kt
@@ -107,6 +107,8 @@ internal class WeatherAppBlobRecordV4Test {
      */
     @Test
     fun encodesUnknownSentinels() {
+        val locationName = "České Budějovice"
+        val forecastShort = "Déšť 🌧️"
         val record = WeatherAppBlobRecordV4(
             currentTemp = 18,
             currentWeatherType = 7u,
@@ -135,14 +137,16 @@ internal class WeatherAppBlobRecordV4Test {
             tomorrowHourlyCount = 0u,
             tomorrowHourlyWeatherType = UByteArray(24) { WeatherType.Unknown.code.toUByte() },
             tomorrowHourlyTemp = ByteArray(24),
-            locationName = "X",
-            forecastShort = "Y",
+            locationName = locationName,
+            forecastShort = forecastShort,
         )
 
         val bytes = record.toBytes()
+        val serializedStringsSize =
+            record.locationName.toBytes().size + record.forecastShort.toBytes().size
 
-        // Fixed portion is 250 bytes; then 2-byte string header + "X" (3) + "Y" (3) = 258 total.
-        assertEquals(258, bytes.size)
+        assertEquals(serializedStringsSize, record.allStringsLength.get().toInt())
+        assertEquals(250 + UShort.SIZE_BYTES + serializedStringsSize, bytes.size)
         // minor_version @18, feels-like @19 (unknown 32767 = FF 7F)
         assertEquals(5u.toUByte(), bytes[18])
         assertUByteArrayEquals(ubyteArrayOf(0xFFu, 0x7Fu), bytes.sliceArray(19..20)) // feels-like


### PR DESCRIPTION
## Summary

- Calculate `allStringsLength` from the serialized UTF-8 byte counts instead
  of Kotlin string lengths.
- Share the calculation between v3 and v4 weather DB records.
- Add regression coverage for empty strings, ASCII, Czech and German
  diacritics, CJK characters, emoji, and combining Unicode characters.

## Problem

Weather location and forecast strings are serialized as `SLongString` values,
with a two-byte length prefix followed by UTF-8 data.

`String.length` does not represent the number of UTF-8 bytes that will be
written. This makes `allStringsLength` too small when either string contains
non-ASCII characters.

For example, with `České Budějovice` and `Overcast`, the record currently
declares 28 bytes but serializes 31 bytes. The resulting weather DB record has
inconsistent metadata and can be rejected or parsed incorrectly by the watch.

## User impact

Users have reported that the built-in Weather app shows
“there is no locations set up” even though a location is configured:

https://www.reddit.com/r/pebble/comments/1w2npmb/new_weather_app_is_no_longer_working/

One user reports that locations outside their country work while their actual
location does not. Another reports that timeline and watchface weather still
work while the built-in Weather app does not.

Those symptoms are consistent with a location-name-dependent Weather DB
serialization problem. This change does not claim to cover every failure
reported in the thread.

## Testing

Ran the complete libpebble3 JVM test suite:

`./gradlew :libpebble3:jvmTest`

Added coverage for:

- empty strings;
- ASCII strings;
- `České Budějovice`;
- `München` and `Déšť`;
- `東京` and `雷雨 🌧️`;
- decomposed and precomposed accents;
- Unicode trailing strings in both v3 and v4 records.

As a mutation check, restoring the original `String.length` calculation causes
both the v3 and v4 regression tests to fail. Restoring the UTF-8 byte
calculation makes the full test suite pass.

## AI disclosure

OpenAI Codex was used to help investigate the issue and prepare the regression
tests and implementation.
