### PR TITLE
protocol: read the watch's refusals instead of dropping them

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/Meta.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/packets/Meta.kt
@@ -1,0 +1,55 @@
+package io.rebble.libpebblecommon.packets
+
+import io.rebble.libpebblecommon.protocolhelpers.PacketRegistry
+import io.rebble.libpebblecommon.protocolhelpers.PebblePacket
+import io.rebble.libpebblecommon.protocolhelpers.ProtocolEndpoint
+import io.rebble.libpebblecommon.structmapper.SOptional
+import io.rebble.libpebblecommon.structmapper.SUByte
+import io.rebble.libpebblecommon.structmapper.SUShort
+import io.rebble.libpebblecommon.structmapper.StructMapper
+import io.rebble.libpebblecommon.util.Endian
+
+/**
+ * Meta endpoint (0x00, spelled [ProtocolEndpoint.RECOVERY]). The watch answers here when it will
+ * not answer on the endpoint that was addressed: an [error] saying why, and the [rejectedEndpoint]
+ * the refused request was for. A recovery firmware refuses nearly every endpoint, so there this is
+ * the only reply most requests get.
+ */
+class MetaMessage : PebblePacket(endpoint) {
+    /**
+     * Why the request was refused. See [Error].
+     */
+    val error = SUByte(m)
+
+    /**
+     * The endpoint the refused request was addressed to. Absent for [Error.CorruptedMessage],
+     * which the watch cannot attribute to an endpoint.
+     */
+    val rejectedEndpoint =
+        SOptional(m, SUShort(StructMapper(), endianness = Endian.Big), present = true)
+
+    enum class Error(val value: UByte) {
+        NoError(0x00u),
+        CorruptedMessage(0xd0u),
+        Unhandled(0xdcu),
+        Disallowed(0xddu),
+        ;
+
+        companion object {
+            fun fromValue(value: UByte): Error? = entries.firstOrNull { it.value == value }
+        }
+    }
+
+    override fun toString(): String {
+        val name = Error.fromValue(error.get())?.name ?: "0x${error.get().toInt().toString(16)}"
+        return "MetaMessage(error=$name, rejectedEndpoint=${rejectedEndpoint.get()})"
+    }
+
+    companion object {
+        val endpoint = ProtocolEndpoint.RECOVERY
+    }
+}
+
+fun metaPacketsRegister() {
+    PacketRegistry.register(MetaMessage.endpoint) { MetaMessage() }
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/protocolhelpers/PacketRegistry.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/protocolhelpers/PacketRegistry.kt
@@ -15,6 +15,7 @@ import io.rebble.libpebblecommon.packets.dataLoggingPacketsRegister
 import io.rebble.libpebblecommon.packets.getBytesIncomingPacketsRegister
 import io.rebble.libpebblecommon.packets.healthSyncPacketsRegister
 import io.rebble.libpebblecommon.packets.logDumpPacketsRegister
+import io.rebble.libpebblecommon.packets.metaPacketsRegister
 import io.rebble.libpebblecommon.packets.musicPacketsRegister
 import io.rebble.libpebblecommon.packets.phoneControlPacketsRegister
 import io.rebble.libpebblecommon.packets.putBytesIncomingPacketsRegister
@@ -34,6 +35,7 @@ object PacketRegistry {
         mutableMapOf()
 
     init {
+        metaPacketsRegister()
         systemPacketsRegister()
         timePacketsRegister()
         timelinePacketsRegister()

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/SystemService.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/SystemService.kt
@@ -14,6 +14,7 @@ import io.rebble.libpebblecommon.metadata.WatchColor.TimeRoundBlackSilverPolish2
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
 import io.rebble.libpebblecommon.metadata.WatchType.CHALK
 import io.rebble.libpebblecommon.packets.FirmwareProperty
+import io.rebble.libpebblecommon.packets.MetaMessage
 import io.rebble.libpebblecommon.packets.PhoneAppVersion
 import io.rebble.libpebblecommon.packets.PingPong
 import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
@@ -21,6 +22,7 @@ import io.rebble.libpebblecommon.packets.ResetMessage
 import io.rebble.libpebblecommon.packets.SystemMessage
 import io.rebble.libpebblecommon.packets.TimeMessage
 import io.rebble.libpebblecommon.packets.WatchFactoryData
+import io.rebble.libpebblecommon.protocolhelpers.ProtocolEndpoint
 import io.rebble.libpebblecommon.packets.WatchFirmwareVersion
 import io.rebble.libpebblecommon.packets.WatchVersion
 import io.rebble.libpebblecommon.packets.WatchVersion.WatchVersionResponse
@@ -211,6 +213,15 @@ class SystemService(
                     is PingPong.Pong -> {
                         pongCallback?.complete(packet)
                         pongCallback = null
+                    }
+
+                    is MetaMessage -> {
+                        if (packet.rejectedEndpoint.get() == ProtocolEndpoint.PING.value) {
+                            pongCallback?.completeExceptionally(
+                                Exception("Watch will not answer a ping: $packet")
+                            )
+                            pongCallback = null
+                        }
                     }
 
                     is TimeMessage.GetTimeUtcRequest-> {

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/packets/MetaTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/packets/MetaTest.kt
@@ -1,0 +1,44 @@
+package io.rebble.libpebblecommon.packets
+
+import assertIs
+import io.rebble.libpebblecommon.protocolhelpers.PebblePacket
+import io.rebble.libpebblecommon.protocolhelpers.ProtocolEndpoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class MetaTest {
+    /** A packet as it arrives: big-endian length, big-endian endpoint, payload. */
+    private fun received(vararg payload: UByte) =
+        ubyteArrayOf(0u, payload.size.toUByte(), 0u, 0u) + payload
+
+    @Test
+    fun anEndpointTheWatchDoesNotHandleIsNamed() {
+        // What a recovery firmware answers a ping with: endpoint 2001, unhandled.
+        val packet = PebblePacket.deserialize(received(0xDCu, 0x07u, 0xD1u))
+
+        assertIs<MetaMessage>(packet)
+        assertEquals(MetaMessage.Error.Unhandled.value, packet.error.get())
+        assertEquals(ProtocolEndpoint.PING.value, packet.rejectedEndpoint.get())
+    }
+
+    @Test
+    fun anEndpointTheWatchWillNotAllowIsNamedTheSameWay() {
+        val packet = PebblePacket.deserialize(received(0xDDu, 0x07u, 0xD1u))
+
+        assertIs<MetaMessage>(packet)
+        assertEquals(MetaMessage.Error.Disallowed.value, packet.error.get())
+        assertEquals(ProtocolEndpoint.PING.value, packet.rejectedEndpoint.get())
+    }
+
+    @Test
+    fun aCorruptedMessageNamesNoEndpoint() {
+        // The firmware cannot attribute this one, so it sends the code alone and
+        // the endpoint has to read as absent rather than as zero.
+        val packet = PebblePacket.deserialize(received(0xD0u))
+
+        assertIs<MetaMessage>(packet)
+        assertEquals(MetaMessage.Error.CorruptedMessage.value, packet.error.get())
+        assertNull(packet.rejectedEndpoint.get())
+    }
+}


### PR DESCRIPTION
## What happens today

Endpoint 0 is the **meta endpoint**. The watch answers there when it will not answer on the endpoint that was addressed — an error code plus the id of the request it concerns (`src/fw/services/comm_session/meta_endpoint.c` in PebbleOS):

| code | meaning |
| --- | --- |
| `0xd0` | corrupted message (no endpoint id follows) |
| `0xdc` | endpoint not handled |
| `0xdd` | endpoint not allowed |

Nothing decodes it:

1. `ProtocolEndpoint.RECOVERY(0u)` is declared and never referenced anywhere in the tree.
2. `PacketRegistry` has no decoder for it, so `get()` throws `PacketDecodeException("No packet class registered for endpoint RECOVERY")`.
3. `PebbleProtocolRunner` swallows that exception and drops the packet — and its `Logger.w` is commented out, so nothing is logged either:

```kotlin
val packet = try { PebblePacket.deserialize(packetBytes) }
catch (e: CancellationException) { throw e }
catch (e: Exception) {
//  Logger.w("error deserializing packet: $packetBytes", e)
    null
}
```

So a refusal is indistinguishable from silence, and a caller awaiting the real answer waits for a reply that is never coming. `SystemService.sendPing` has no deadline of its own — unlike `getFirmwareUpdateStatus` two dozen lines above it, which wraps its await in `withTimeoutOrNull` — so it never returns.

## Where this bites

A watch in its recovery firmware refuses nearly every endpoint. Ping it and it answers endpoint 0 with `DC 07 D1` — "endpoint 2001 is not handled here" — which is both a refusal *and* proof the watch is alive.

I hit this from a third-party iOS companion app I maintain: reading the refusal as "no answer" made me tear the link down, which stopped a firmware install on a recovery-firmware watch every time. Reading it as "alive, but not on that endpoint" fixed it. Observed on a Pebble Time 2 (`obelix_pvt`) in PRF v4.9.142.

## The change

- `MetaMessage` decodes the endpoint. The endpoint id is `SOptional`, because `0xd0` does not carry one.
- `SystemService` fails a pending ping when the watch says it will not answer one — the same shape as `WatchFactoryDataError` failing a pending watch-model request a few lines above.
- ProtocolEndpoint.RECOVERY(0u) is kept for API compatibility; MetaMessage uses it as the protocol's meta endpoint.

## Deliberately not in scope

- `requestWatchVersion` and `getWatchModel` await without deadlines too, and could be failed from the same handler. Recovery firmware *does* answer endpoint 16, so they are less exposed; say the word and I will wire them.
- The commented-out `Logger.w` in `PebbleProtocolRunner` is left alone — restoring it looks like a good idea and is a separate concern.
- No timeout was added to `sendPing`. That changes what callers see on a genuinely silent watch, which is a semantics decision for you rather than a bug fix. A refusal now unblocks it; silence still does not.

## Tests

`MetaTest` covers the two shapes the meta endpoint sends: the refusal that names an endpoint, and the one that cannot.

```
./gradlew :libpebble3:jvmTest --tests 'io.rebble.libpebblecommon.packets.MetaTest'
  anEndpointTheWatchDoesNotHandleIsNamed          PASS
  anEndpointTheWatchWillNotAllowIsNamedTheSameWay PASS
  aCorruptedMessageNamesNoEndpoint                PASS
```

Full suite on this branch: 206 tests, no failures. The third case is the one worth having — it is why `rejectedEndpoint` is an `SOptional`, and it fails if absent decodes as endpoint 0 instead of as absent.

**Correcting my own earlier note:** an earlier version of this description said there was no Gradle wrapper in the tree and that I could not compile Kotlin here. Both were wrong, and I had not checked either. `./gradlew :libpebble3:compileKotlinJvm` and `:libpebble3:jvmTest` work once `local.properties` names an Android SDK and a JDK 17 is on the toolchain path. (`compileKotlinMetadata` reports SKIPPED and verifies nothing, which is what misled me the first time.)

The checks I had made by reading still hold, and are what the tests now confirm:

- the universal-decoder shape matches `PacketRegistry.register(ProtocolEndpoint.APP_LOGS) { AppLogReceivedMessage() }`
- `PebblePacket.deserialize` consumes the 4-byte frame into a throwaway mapper before calling `packet.m.fromBytes(buf)`, so the fields start after the header
- `SOptional.fromBytes` marks itself absent when fewer than `value.size` bytes remain, which is what makes the `0xd0` case work
- the inner element takes a throwaway `StructMapper()`, as in `PutBytes.kt:49`
- `UByte` has no `toString(radix)`, so hex goes through `toInt()`, as in `ProtocolEndpoint.kt:47`

`SystemService`'s ping path is not covered: driving it needs a connection scope and a `pongCallback` in flight, which is a larger fixture than the decode. Happy to add it if you would rather have it.

## AI use

Written with Claude Code (Claude Opus 5), disclosed per CONTRIBUTING. I have read the change and the firmware behaviour it describes, and can explain either.