### PR TITLE
feat(index): add approximate location to webhooks

### DIFF
--- a/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
+++ b/androidApp/src/androidTest/kotlin/coredevices/coreapp/evals/RingRecordingE2ETest.kt
@@ -667,6 +667,7 @@ class RingRecordingE2ETest {
                     gesture: coredevices.ring.service.button.RingGesture,
                     url: String,
                     headers: Map<String, String>,
+                    includeLocation: Boolean,
                 ) = coredevices.ring.external.indexwebhook.IndexWebhookRunResult(
                     ok = true, status = "200 OK", detail = "test event", byteSize = 0, durationMs = 0,
                 )

--- a/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
+++ b/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
@@ -265,6 +265,7 @@ class RecordingProcessingQueueTest {
                     gesture: coredevices.ring.service.button.RingGesture,
                     url: String,
                     headers: Map<String, String>,
+                    includeLocation: Boolean,
                 ) = coredevices.ring.external.indexwebhook.IndexWebhookRunResult(
                     ok = true, status = "200 OK", detail = "test event", byteSize = 0, durationMs = 0,
                 )

--- a/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/experimentalModule.kt
@@ -217,7 +217,9 @@ val experimentalModule = module {
             get(),
             get(),
             get(),
-            get<RecordingBackgroundScope>()
+            get<RecordingBackgroundScope>(),
+            get(),
+            get(),
         )
     } bind IndexWebhookApi::class
 

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/INDEX_WEBHOOK_API.md
@@ -9,7 +9,8 @@ Send Index ring recording data to any HTTP endpoint.
 3. Enter your webhook URL
 4. Add any request headers you need (e.g. an auth header)
 5. Choose what to send: Recording only, Transcription only, or Both
-6. Optionally tap **Send test event** to verify the endpoint, then **Save**
+6. Optionally enable **Include approximate location**
+7. Optionally tap **Send test event** to verify the endpoint, then **Save**
 
 A gesture only sends once its config is saved with a URL. The switch turns sending off without discarding the URL and headers, and the last 20 runs per gesture are listed under **Recent runs**.
 
@@ -52,13 +53,23 @@ Unix timestamp in milliseconds when the recording was captured.
 
 Always set to `"ring"`.
 
+### Location fields (conditional)
+
+When **Include approximate location** is enabled and the phone can provide a recent fix, the request includes all three fields:
+
+- `locationLatitude`: decimal degrees rounded to three decimal places
+- `locationLongitude`: decimal degrees rounded to three decimal places
+- `locationTimestamp`: Unix timestamp in milliseconds for the phone's location fix
+
+Location is best effort. The webhook still sends without these fields when permission is denied or a recent fix is unavailable. `locationTimestamp` is usually close to webhook delivery time, while `recordedAt` is the ring capture time. Sync and processing delays mean the phone location may differ from where the recording was made.
+
 ## Payload Modes
 
-| Mode               | `audio` | `transcription` | `recordedAt` | `client` |
-|--------------------|---------|-----------------|--------------|----------|
-| Recording only     | Yes     | No              | Yes          | Yes      |
-| Transcription only | No      | Yes             | Yes          | Yes      |
-| Both               | Yes     | Yes             | Yes          | Yes      |
+| Mode               | `audio` | `transcription` | `recordedAt` | `client` | Location fields |
+|--------------------|---------|-----------------|--------------|----------|-----------------|
+| Recording only     | Yes     | No              | Yes          | Yes      | If enabled and available |
+| Transcription only | No      | Yes             | Yes          | Yes      | If enabled and available |
+| Both               | Yes     | Yes             | Yes          | Yes      | If enabled and available |
 
 ## Headers
 
@@ -90,6 +101,9 @@ def receive():
     audio = request.files.get('audio')
     transcription = request.form.get('transcription')
     recorded_at = request.form.get('recordedAt')
+    location_latitude = request.form.get('locationLatitude')
+    location_longitude = request.form.get('locationLongitude')
+    location_timestamp = request.form.get('locationTimestamp')
     trigger = request.headers.get('X-Index-Trigger')
 
     if audio:
@@ -99,6 +113,9 @@ def receive():
     if transcription:
         print(f'Transcription: {transcription}')
 
+    if location_latitude and location_longitude and location_timestamp:
+        print(f'Phone location: {location_latitude}, {location_longitude} at {location_timestamp}')
+
     print(f'Recorded at: {recorded_at}')
     print(f'Trigger: {trigger}')
     return 'OK', 200
@@ -107,6 +124,7 @@ def receive():
 ## Notes
 
 - Uploads are async and non-blocking — they don't delay the normal recording pipeline
+- An enabled location lookup can add up to one second before the async webhook delivery
 - Failed uploads are retried on the next recording (no persistent retry queue)
 - The webhook fires as early as its payload allows, in parallel with the rest of the pipeline: `RecordingOnly` sends as soon as the audio is on disk (before transcription); modes that include the transcript send once it is transcribed, concurrently with agent processing. The webhook therefore fires even if agent processing (or, for the recording-only mode, transcription) later fails.
 - Audio is the same 16kHz resampled version used for transcription

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookApi.kt
@@ -1,10 +1,14 @@
 package coredevices.ring.external.indexwebhook
 
 import co.touchlab.kermit.Logger
+import coredevices.HackyPermissionRequesterProvider
 import coredevices.api.ApiClient
 import coredevices.ring.api.ApiConfig
 import coredevices.ring.audio.M4aEncoder
 import coredevices.ring.service.button.RingGesture
+import coredevices.util.Permission
+import io.rebble.libpebblecommon.util.GeolocationPositionResult
+import io.rebble.libpebblecommon.util.SystemGeolocation
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -14,8 +18,11 @@ import io.ktor.http.content.ByteArrayContent
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlin.math.round
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlin.time.TimeSource
 import kotlin.uuid.Uuid
@@ -46,6 +53,7 @@ interface IndexWebhookApi {
         gesture: RingGesture,
         url: String,
         headers: Map<String, String>,
+        includeLocation: Boolean,
     ): IndexWebhookRunResult
 }
 
@@ -56,6 +64,44 @@ data class IndexWebhookRunResult(
     val byteSize: Long,
     val durationMs: Long,
 )
+
+internal data class IndexWebhookLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val timestamp: Long,
+)
+
+internal fun indexWebhookLocation(
+    result: GeolocationPositionResult.Success,
+    now: Instant,
+): IndexWebhookLocation? {
+    if (!result.latitude.isFinite() || result.latitude !in -90.0..90.0) return null
+    if (!result.longitude.isFinite() || result.longitude !in -180.0..180.0) return null
+    if (result.timestamp > now || result.timestamp < now - 1.hours) return null
+    return IndexWebhookLocation(
+        latitude = round(result.latitude * 1000) / 1000,
+        longitude = round(result.longitude * 1000) / 1000,
+        timestamp = result.timestamp.toEpochMilliseconds(),
+    )
+}
+
+internal suspend fun resolveIndexWebhookLocation(
+    includeLocation: Boolean,
+    hasPermission: suspend () -> Boolean,
+    getCurrentPosition: suspend () -> GeolocationPositionResult,
+    now: () -> Instant,
+): IndexWebhookLocation? {
+    if (!includeLocation) return null
+    return try {
+        if (!hasPermission()) return null
+        when (val result = getCurrentPosition()) {
+            is GeolocationPositionResult.Success -> indexWebhookLocation(result, now())
+            is GeolocationPositionResult.Error -> null
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
 
 /** Value of the `X-Index-Trigger` header. Endpoints key off these, do not rename them. */
 val RingGesture.webhookTriggerValue: String
@@ -80,6 +126,8 @@ class IndexWebhookApiImpl(
     private val webhookPreferences: IndexWebhookPreferences,
     private val runRepository: IndexWebhookRunRepository,
     private val scope: CoroutineScope,
+    private val permissionProvider: HackyPermissionRequesterProvider,
+    private val geolocation: SystemGeolocation,
 ) : IndexWebhookApi, ApiClient(config.version, timeout = 2.minutes, followAllRedirects = true) {
 
     companion object {
@@ -104,6 +152,7 @@ class IndexWebhookApiImpl(
 
                 // The caller already selected the payload for the delivery's mode.
                 val m4aData: ByteArray? = samples?.let { m4aEncoder.encode(it, sampleRate) }
+                val location = currentLocation(config.includeLocation)
 
                 val result = post(
                     url = url,
@@ -114,6 +163,7 @@ class IndexWebhookApiImpl(
                     transcription = transcription,
                     recordedAt = recordedAt,
                     isTest = false,
+                    location = location,
                 )
                 runRepository.record(
                     gesture = gesture,
@@ -138,6 +188,7 @@ class IndexWebhookApiImpl(
         gesture: RingGesture,
         url: String,
         headers: Map<String, String>,
+        includeLocation: Boolean,
     ): IndexWebhookRunResult {
         val result = post(
             url = url,
@@ -148,6 +199,7 @@ class IndexWebhookApiImpl(
             transcription = WEBHOOK_TEST_TRANSCRIPTION,
             recordedAt = Clock.System.now(),
             isTest = true,
+            location = currentLocation(includeLocation),
         )
         runRepository.record(
             gesture = gesture,
@@ -160,6 +212,21 @@ class IndexWebhookApiImpl(
         return result
     }
 
+    private suspend fun currentLocation(includeLocation: Boolean): IndexWebhookLocation? {
+        return resolveIndexWebhookLocation(
+            includeLocation = includeLocation,
+            hasPermission = { permissionProvider.get().hasPermission(Permission.Location) },
+            getCurrentPosition = {
+                geolocation.getCurrentPosition(
+                    maximumAge = 1.hours,
+                    timeout = 1.seconds,
+                    highAccuracy = false,
+                )
+            },
+            now = Clock.System::now,
+        )
+    }
+
     private suspend fun post(
         url: String,
         headers: Map<String, String>,
@@ -169,6 +236,7 @@ class IndexWebhookApiImpl(
         transcription: String?,
         recordedAt: Instant,
         isTest: Boolean,
+        location: IndexWebhookLocation?,
     ): IndexWebhookRunResult {
         val boundary = Uuid.random().toString()
         val bodyBytes = buildWebhookMultipartBody(
@@ -178,6 +246,7 @@ class IndexWebhookApiImpl(
             recordedAt = recordedAt.toEpochMilliseconds(),
             transcription = transcription,
             isTest = isTest,
+            location = location,
         )
         val started = TimeSource.Monotonic.markNow()
         return try {
@@ -247,6 +316,7 @@ internal fun buildWebhookMultipartBody(
     recordedAt: Long,
     transcription: String?,
     isTest: Boolean,
+    location: IndexWebhookLocation? = null,
 ): ByteArray {
     val crlf = "\r\n"
     val parts = mutableListOf<ByteArray>()
@@ -274,6 +344,19 @@ internal fun buildWebhookMultipartBody(
         metadata.append("--$boundary$crlf")
         metadata.append("Content-Disposition: form-data; name=\"test\"$crlf$crlf")
         metadata.append("true$crlf")
+    }
+    if (location != null) {
+        metadata.append("--$boundary$crlf")
+        metadata.append("Content-Disposition: form-data; name=\"locationLatitude\"$crlf$crlf")
+        metadata.append("${location.latitude}$crlf")
+
+        metadata.append("--$boundary$crlf")
+        metadata.append("Content-Disposition: form-data; name=\"locationLongitude\"$crlf$crlf")
+        metadata.append("${location.longitude}$crlf")
+
+        metadata.append("--$boundary$crlf")
+        metadata.append("Content-Disposition: form-data; name=\"locationTimestamp\"$crlf$crlf")
+        metadata.append("${location.timestamp}$crlf")
     }
     metadata.append("--$boundary$crlf")
     metadata.append("Content-Disposition: form-data; name=\"recordedAt\"$crlf$crlf")

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferences.kt
@@ -30,6 +30,7 @@ enum class IndexWebhookPayloadMode(val id: Int) {
 data class IndexWebhookConfig(
     val url: String? = null,
     val payloadMode: IndexWebhookPayloadMode = IndexWebhookPayloadMode.RecordingOnly,
+    val includeLocation: Boolean = false,
     val headers: Map<String, String> = emptyMap(),
     val saved: Boolean = false,
 ) {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSettingsViewModel.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSettingsViewModel.kt
@@ -56,6 +56,9 @@ class IndexWebhookSettingsViewModel(
     private val _payloadModeInput = MutableStateFlow(IndexWebhookPayloadMode.RecordingOnly)
     val payloadModeInput = _payloadModeInput.asStateFlow()
 
+    private val _includeLocationInput = MutableStateFlow(false)
+    val includeLocationInput = _includeLocationInput.asStateFlow()
+
     private val _testState = MutableStateFlow<WebhookTestState>(WebhookTestState.Idle)
     val testState = _testState.asStateFlow()
 
@@ -120,6 +123,10 @@ class IndexWebhookSettingsViewModel(
         _payloadModeInput.value = mode
     }
 
+    fun updateIncludeLocation(includeLocation: Boolean) {
+        _includeLocationInput.value = includeLocation
+    }
+
     fun copyFromOtherGesture() {
         val other = copyableGesture.value ?: return
         loadDraft(webhookPreferences.configFor(other))
@@ -130,7 +137,12 @@ class IndexWebhookSettingsViewModel(
         val url = _urlInput.value.trim().ifBlank { null } ?: return
         _testState.value = WebhookTestState.Sending
         viewModelScope.launch {
-            val result = webhookApi.sendTestEvent(gesture, url, draftHeaders())
+            val result = webhookApi.sendTestEvent(
+                gesture,
+                url,
+                draftHeaders(),
+                _includeLocationInput.value,
+            )
             _testState.value = WebhookTestState.Done(
                 ok = result.ok,
                 label = "${result.status} · ${result.durationMs} ms",
@@ -149,6 +161,7 @@ class IndexWebhookSettingsViewModel(
                 IndexWebhookConfig(
                     url = url,
                     payloadMode = _payloadModeInput.value,
+                    includeLocation = _includeLocationInput.value,
                     headers = draftHeaders(),
                     saved = true,
                 ),
@@ -163,6 +176,7 @@ class IndexWebhookSettingsViewModel(
             .map { WebhookHeaderInput(it.key, it.value) }
             .ifEmpty { listOf(WebhookHeaderInput("", "")) }
         _payloadModeInput.value = config.payloadMode
+        _includeLocationInput.value = config.includeLocation
     }
 
     /** Drops rows with a blank name; later rows win on duplicate names. */

--- a/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSheet.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -62,6 +63,7 @@ fun IndexWebhookSheet(
     val urlInput by viewModel.urlInput.collectAsState()
     val headerInputs by viewModel.headerInputs.collectAsState()
     val payloadMode by viewModel.payloadModeInput.collectAsState()
+    val includeLocation by viewModel.includeLocationInput.collectAsState()
     val testState by viewModel.testState.collectAsState()
     val copyable by viewModel.copyableGesture.collectAsState()
     val canRemove by viewModel.canRemove.collectAsState()
@@ -141,6 +143,26 @@ fun IndexWebhookSheet(
                         }
                     }
                 }
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Include approximate location", style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "Adds this phone's location when the webhook is sent, rounded to ~100 m. " +
+                            "This may differ from where the recording was made.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = includeLocation,
+                    onCheckedChange = viewModel::updateIncludeLocation,
+                )
             }
 
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookLocationTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookLocationTest.kt
@@ -1,0 +1,119 @@
+package coredevices.ring.external.indexwebhook
+
+import io.rebble.libpebblecommon.util.GeolocationPositionResult
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class IndexWebhookLocationTest {
+
+    private val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    @Test
+    fun validLocationIsRoundedToThreeDecimals() {
+        val location = indexWebhookLocation(
+            success(latitude = 37.7749, longitude = -122.4194),
+            now,
+        )
+
+        assertEquals(
+            IndexWebhookLocation(
+                latitude = 37.775,
+                longitude = -122.419,
+                timestamp = now.toEpochMilliseconds(),
+            ),
+            location,
+        )
+    }
+
+    @Test
+    fun staleOrFutureLocationIsRejected() {
+        assertNull(indexWebhookLocation(success(timestamp = now - 1.hours - 1.seconds), now))
+        assertNull(indexWebhookLocation(success(timestamp = now + 1.hours), now))
+    }
+
+    @Test
+    fun invalidCoordinatesAreRejected() {
+        assertNull(indexWebhookLocation(success(latitude = Double.NaN), now))
+        assertNull(indexWebhookLocation(success(longitude = 181.0), now))
+    }
+
+    @Test
+    fun disabledLocationDoesNotCheckPermissionOrPosition() = runTest {
+        var permissionChecks = 0
+        var positionRequests = 0
+
+        val location = resolveIndexWebhookLocation(
+            includeLocation = false,
+            hasPermission = {
+                permissionChecks++
+                true
+            },
+            getCurrentPosition = {
+                positionRequests++
+                success()
+            },
+            now = { now },
+        )
+
+        assertNull(location)
+        assertEquals(0, permissionChecks)
+        assertEquals(0, positionRequests)
+    }
+
+    @Test
+    fun deniedPermissionDoesNotRequestPosition() = runTest {
+        var positionRequests = 0
+
+        val location = resolveIndexWebhookLocation(
+            includeLocation = true,
+            hasPermission = { false },
+            getCurrentPosition = {
+                positionRequests++
+                success()
+            },
+            now = { now },
+        )
+
+        assertNull(location)
+        assertEquals(0, positionRequests)
+    }
+
+    @Test
+    fun positionErrorsAndExceptionsOmitLocation() = runTest {
+        assertNull(
+            resolveIndexWebhookLocation(
+                includeLocation = true,
+                hasPermission = { true },
+                getCurrentPosition = { GeolocationPositionResult.Error("unavailable") },
+                now = { now },
+            )
+        )
+        assertNull(
+            resolveIndexWebhookLocation(
+                includeLocation = true,
+                hasPermission = { true },
+                getCurrentPosition = { error("provider failed") },
+                now = { now },
+            )
+        )
+    }
+
+    private fun success(
+        timestamp: Instant = now,
+        latitude: Double = 1.0,
+        longitude: Double = 2.0,
+    ) = GeolocationPositionResult.Success(
+        timestamp = timestamp,
+        latitude = latitude,
+        longitude = longitude,
+        accuracy = null,
+        altitude = null,
+        heading = null,
+        speed = null,
+    )
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferencesTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookPreferencesTest.kt
@@ -107,6 +107,7 @@ class IndexWebhookPreferencesTest {
         val hold = IndexWebhookConfig(
             url = "https://hold.example.com",
             payloadMode = IndexWebhookPayloadMode.TranscriptionOnly,
+            includeLocation = true,
             headers = mapOf("X-A" to "1"),
             saved = true,
         )
@@ -184,6 +185,7 @@ class IndexWebhookPreferencesTest {
         val prefs = IndexWebhookPreferences(settings)
 
         assertEquals("https://example.com/hook", prefs.configFor(RingGesture.Hold).url)
+        assertFalse(prefs.configFor(RingGesture.Hold).includeLocation)
         assertEquals("https://example.com/hook", prefs.configFor(RingGesture.ClickHold).url)
         assertTrue(prefs.configFor(RingGesture.Hold).isActive)
         assertEquals(null, settings.getStringOrNull("index_webhook_config_SingleClickHold"))

--- a/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookTestEventPayloadTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/external/indexwebhook/IndexWebhookTestEventPayloadTest.kt
@@ -56,6 +56,36 @@ class IndexWebhookTestEventPayloadTest {
     }
 
     @Test
+    fun locationFieldsAreAllIncludedWhenAvailable() {
+        val body = buildWebhookMultipartBody(
+            boundary = "BOUNDARY",
+            audioData = null,
+            filename = "recording.m4a",
+            recordedAt = 1L,
+            transcription = "hello",
+            isTest = false,
+            location = IndexWebhookLocation(
+                latitude = 37.775,
+                longitude = -122.419,
+                timestamp = 1_700_000_000_000L,
+            ),
+        ).decodeToString()
+
+        assertTrue(body.contains("name=\"locationLatitude\"\r\n\r\n37.775\r\n"))
+        assertTrue(body.contains("name=\"locationLongitude\"\r\n\r\n-122.419\r\n"))
+        assertTrue(body.contains("name=\"locationTimestamp\"\r\n\r\n1700000000000\r\n"))
+    }
+
+    @Test
+    fun locationFieldsAreAllOmittedWhenUnavailable() {
+        val body = testEventBody()
+
+        assertFalse(body.contains("name=\"locationLatitude\""))
+        assertFalse(body.contains("name=\"locationLongitude\""))
+        assertFalse(body.contains("name=\"locationTimestamp\""))
+    }
+
+    @Test
     fun testEventTriggerValueIsDistinctFromEveryGestureValue() {
         assertEquals("test-event", WEBHOOK_TEST_TRIGGER)
         assertTrue(

--- a/experimental/src/commonTest/kotlin/coredevices/ring/service/recordings/button/IndexWebhookUploadRecordingOperationTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/service/recordings/button/IndexWebhookUploadRecordingOperationTest.kt
@@ -178,6 +178,7 @@ private class FakeWebhookApi : IndexWebhookApi {
         gesture: RingGesture,
         url: String,
         headers: Map<String, String>,
+        includeLocation: Boolean,
     ) = throw NotImplementedError("unused")
 }
 


### PR DESCRIPTION
## Summary

- add a per-gesture opt-in for approximate phone location in Index webhooks
- send `locationLatitude`, `locationLongitude`, and `locationTimestamp` together when a recent fix is available
- keep webhook delivery best effort when location permission or a recent fix is unavailable

Coordinates are rounded to three decimal places. The UI and API docs clarify that this is the phone location near webhook delivery, which may differ from the ring recording location.

## Testing

- Added common tests for opt-in privacy behavior, permission and provider failure fallback, freshness and coordinate validation, multipart serialization, and preference compatibility.
- Not run locally: Gradle configuration requires an Android SDK, which is not installed in this environment. GitHub Actions will provide build validation.

## AI assistance

AI was used to review the existing architecture, draft the implementation, and identify test cases. I reviewed the code and kept the change scoped to webhook configuration, request construction, documentation, and tests.