### PR TITLE
firmware: give the update handshake a deadline

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/FirmwareUpdater.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/FirmwareUpdater.kt
@@ -30,12 +30,16 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.RawSource
 import kotlinx.io.Source
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlin.concurrent.atomics.AtomicReference
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
+
+private val FIRMWARE_UPDATE_START_TIMEOUT = 15.seconds
 
 sealed class FirmwareUpdateException(message: String, cause: Throwable? = null) :
     Exception(message, cause) {
@@ -476,10 +480,17 @@ class RealFirmwareUpdater(
                 _firmwareUpdateState.value = FirmwareUpdateStatus.NotInProgress.Idle()
                 return
             }
-            val result = systemService.sendFirmwareUpdateStart(
-                bytesAlreadyTransferred = resume.total,
-                bytesToSend = totalBytes.toUInt() - resume.total,
-            )
+            // Not withTimeout: a TimeoutCancellationException would be caught
+            // below as a cancellation and reported as a download failure.
+            val result = withTimeoutOrNull(FIRMWARE_UPDATE_START_TIMEOUT) {
+                systemService.sendFirmwareUpdateStart(
+                    bytesAlreadyTransferred = resume.total,
+                    bytesToSend = totalBytes.toUInt() - resume.total,
+                )
+            }
+            if (result == null) {
+                error("The watch did not answer the firmware update start within $FIRMWARE_UPDATE_START_TIMEOUT")
+            }
             if (result != SystemMessage.FirmwareUpdateStartStatus.Started) {
                 error("Failed to start firmware update: $result")
             }


### PR DESCRIPTION
`beginFirmwareUpdate` waits for the watch to answer `FirmwareUpdateStart` with no deadline. If the answer never comes, it sits on the `await`: `_firmwareUpdateState` keeps whatever value it held, nothing is reported as failed, and `interruptedUpdates` is never told about the attempt. It only unblocks when the connection scope is cancelled from somewhere else.

Everything else in this path already has a deadline:

| wait | deadline | where |
| --- | --- | --- |
| `requestWatchVersion` → `requestWatchColor` | 20s | `Negotiator.negotiate`, which catches `TimeoutCancellationException` and returns a null `WatchInfo` |
| `requestFirmwareUpdateStatus` | 15s | its own `withTimeoutOrNull`, returning null so the transfer starts from scratch |
| `sendFirmwareUpdateStart` | — | nothing |

So this gives it the same 15 seconds, and an unanswered start now takes the path a refused one already took — `error(...)`, caught by the `IllegalStateException` branch below, `Idle(e)`.

### Why `withTimeoutOrNull` and not `withTimeout`

The `try` this sits in has

```kotlin
} catch (e: CancellationException) {
   _firmwareUpdateState.value =
      FirmwareUpdateStatus.NotInProgress.ErrorStarting(FirmwareUpdateErrorStarting.ErrorDownloading)
   throw e
}
```

`TimeoutCancellationException` is a `CancellationException`, so `withTimeout` here would be reported as a download failure — neither what happened nor recoverable the same way. There is a comment on the call saying so, since the next person to touch it will reach for `withTimeout` first.
