### PR TITLE
Android home-screen widget: recent Index notes & to-dos

### DIFF
--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/navigation/CoreDeepLinkHandler.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/navigation/CoreDeepLinkHandler.kt
@@ -17,6 +17,7 @@ class CoreDeepLinkHandler {
         logger.d { "handle: uri = $uri" }
         objectRouteFor(uri)?.let { return _navigateToDeepLink.tryEmit(it) }
         recordingRouteFor(uri)?.let { return _navigateToDeepLink.tryEmit(it) }
+        allListsRouteFor(uri)?.let { return _navigateToDeepLink.tryEmit(it) }
         return _navigateToDeepLink.tryEmit(NavUri(uri.toString()))
     }
 
@@ -41,6 +42,15 @@ class CoreDeepLinkHandler {
         val id = uri.getQueryParameter(RingRoutes.OBJECT_DEEP_LINK_ID_PARAM)?.toLongOrNull()
             ?: return null
         return RingRoutes.RecordingDetails(id)
+    }
+
+    /** `pebblecore://deep-link/all-lists` opens the lists grid (used by the
+     *  Android home-screen widget's "Notes" header). */
+    internal fun allListsRouteFor(uri: Uri): RingRoutes.AllLists? {
+        if (uri.scheme != SCHEME) return null
+        if (uri.host != RingRoutes.OBJECT_DEEP_LINK_HOST) return null
+        if (uri.pathSegments.firstOrNull() != RingRoutes.ALL_LISTS_DEEP_LINK_PATH) return null
+        return RingRoutes.AllLists
     }
 
     fun clearPendingDeepLink() {

--- a/composeApp/src/commonTest/kotlin/coredevices/coreapp/ui/navigation/CoreDeepLinkHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/coredevices/coreapp/ui/navigation/CoreDeepLinkHandlerTest.kt
@@ -46,4 +46,15 @@ class CoreDeepLinkHandlerTest {
     fun objectDeepLinkWithBlankIdDoesNotParse() {
         assertNull(handler.objectRouteFor(Uri.parse("pebblecore://deep-link/object?id=")))
     }
+
+    @Test
+    fun allListsDeepLinkParsesToAllLists() {
+        assertEquals(RingRoutes.AllLists, handler.allListsRouteFor(Uri.parse(RingRoutes.allListsDeepLink())))
+    }
+
+    @Test
+    fun allListsDeepLinkWithWrongSchemeOrPathDoesNotParse() {
+        assertNull(handler.allListsRouteFor(Uri.parse("pebble://deep-link/all-lists")))
+        assertNull(handler.allListsRouteFor(Uri.parse("pebblecore://deep-link/object?id=1")))
+    }
 }

--- a/experimental/src/androidMain/AndroidManifest.xml
+++ b/experimental/src/androidMain/AndroidManifest.xml
@@ -52,6 +52,19 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/voice_widget_info" />
         </receiver>
+        <!-- Always enabled: users opt in via the OS widget picker, and disabling the
+             component would strip placed instances. Disabled/signed-out states are
+             rendered as widget content instead. -->
+        <receiver android:name=".glance.IndexNotesWidgetReceiver"
+                  android:exported="true"
+                  android:enabled="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/index_notes_widget_info" />
+        </receiver>
         <receiver android:name="coredevices.ring.reminders.ReminderReceiver"
                     android:exported="false">
         </receiver>

--- a/experimental/src/androidMain/kotlin/coredevices/ring/RingDelegate.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/RingDelegate.android.kt
@@ -16,15 +16,12 @@ import coredevices.ring.glance.IndexNotesWidget
 import coredevices.ring.glance.VoiceWidgetReceiver
 import coredevices.util.CoreConfigHolder
 import coredevices.util.Permission
-import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.auth.auth
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -50,26 +47,20 @@ actual class RingDelegate(
     private data class WidgetRenderState(
         val fingerprint: List<Triple<String, String, String>>,
         val itemCount: Int,
-        val uid: String?,
         val enableIndex: Boolean,
     )
 
-    /** Pushes a refresh to [IndexNotesWidget] whenever its rendered content, the
-     *  signed-in user, or the Index toggle changes. `updatePeriodMillis` in the
-     *  provider XML is only a best-effort fallback. */
+    /** Pushes a refresh to [IndexNotesWidget] whenever its rendered content or the
+     *  Index toggle changes. `updatePeriodMillis` in the provider XML is only a
+     *  best-effort fallback. */
     @OptIn(FlowPreview::class)
     private fun monitorIndexNotesWidget() {
-        val authUser = flow {
-            emit(Firebase.auth.currentUser)
-            Firebase.auth.authStateChanged.collect { emit(it) }
-        }
         combine(
-            itemRepo.getAllFlow().debounce(500), // coalesce write bursts; auth/config pass through
-            authUser,
+            itemRepo.getAllFlow().debounce(500), // coalesce write bursts; config passes through
             coreConfigHolder.config.map { it.enableIndex }.distinctUntilChanged(),
-        ) { items, user, enableIndex ->
+        ) { items, enableIndex ->
             val rows = recentNotesAndTodos(items)
-            WidgetRenderState(widgetRenderFingerprint(rows), rows.size, user?.uid, enableIndex)
+            WidgetRenderState(widgetRenderFingerprint(rows), rows.size, enableIndex)
         }
             .distinctUntilChanged()
             .onEach { state ->

--- a/experimental/src/androidMain/kotlin/coredevices/ring/RingDelegate.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/RingDelegate.android.kt
@@ -7,11 +7,13 @@ import androidx.glance.appwidget.updateAll
 import co.touchlab.kermit.Logger
 import com.russhwolf.settings.Settings
 import coredevices.HackyPermissionRequesterProvider
+import coredevices.ring.data.entity.room.indexfeed.displayTitle
 import coredevices.ring.data.entity.room.indexfeed.recentNotesAndTodos
 import coredevices.ring.data.entity.room.indexfeed.widgetRenderFingerprint
 import coredevices.ring.database.firestore.FirestoreKnownRingsSync
 import coredevices.ring.database.firestore.dao.FirestoreRecordingsDao
 import coredevices.ring.database.room.repository.ItemRepository
+import coredevices.ring.database.room.repository.ListRepository
 import coredevices.ring.glance.IndexNotesWidget
 import coredevices.ring.glance.VoiceWidgetReceiver
 import coredevices.util.CoreConfigHolder
@@ -34,6 +36,7 @@ actual class RingDelegate(
     private val settings: Settings,
     private val firestoreKnownRingsSync: FirestoreKnownRingsSync,
     private val itemRepo: ItemRepository,
+    private val listRepo: ListRepository,
 ) {
     private val logger = Logger.withTag("RingDelegate")
 
@@ -56,11 +59,13 @@ actual class RingDelegate(
     @OptIn(FlowPreview::class)
     private fun monitorIndexNotesWidget() {
         combine(
-            itemRepo.getAllFlow().debounce(500), // coalesce write bursts; config passes through
+            itemRepo.getAllFlow().debounce(500), // coalesce write bursts; lists/config pass through
+            listRepo.getAllFlow(),
             coreConfigHolder.config.map { it.enableIndex }.distinctUntilChanged(),
-        ) { items, enableIndex ->
+        ) { items, lists, enableIndex ->
             val rows = recentNotesAndTodos(items)
-            WidgetRenderState(widgetRenderFingerprint(rows), rows.size, enableIndex)
+            val titles = lists.associate { it.firestoreId to it.displayTitle }
+            WidgetRenderState(widgetRenderFingerprint(rows, titles), rows.size, enableIndex)
         }
             .distinctUntilChanged()
             .onEach { state ->

--- a/experimental/src/androidMain/kotlin/coredevices/ring/RingDelegate.android.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/RingDelegate.android.kt
@@ -3,16 +3,28 @@ package coredevices.ring
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.glance.appwidget.updateAll
 import co.touchlab.kermit.Logger
 import com.russhwolf.settings.Settings
 import coredevices.HackyPermissionRequesterProvider
+import coredevices.ring.data.entity.room.indexfeed.recentNotesAndTodos
+import coredevices.ring.data.entity.room.indexfeed.widgetRenderFingerprint
 import coredevices.ring.database.firestore.FirestoreKnownRingsSync
 import coredevices.ring.database.firestore.dao.FirestoreRecordingsDao
+import coredevices.ring.database.room.repository.ItemRepository
+import coredevices.ring.glance.IndexNotesWidget
 import coredevices.ring.glance.VoiceWidgetReceiver
 import coredevices.util.CoreConfigHolder
 import coredevices.util.Permission
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.auth.auth
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -24,8 +36,54 @@ actual class RingDelegate(
     private val recordingsDao: FirestoreRecordingsDao,
     private val settings: Settings,
     private val firestoreKnownRingsSync: FirestoreKnownRingsSync,
+    private val itemRepo: ItemRepository,
 ) {
     private val logger = Logger.withTag("RingDelegate")
+
+    init {
+        // Registered at construction (Koin builds this during MainApplication.onCreate),
+        // not in init(), which runs later behind the async weatherFetcher chain.
+        monitorIndexNotesWidget()
+    }
+
+    /** What the widget renders; identical states don't trigger a refresh. */
+    private data class WidgetRenderState(
+        val fingerprint: List<Triple<String, String, String>>,
+        val itemCount: Int,
+        val uid: String?,
+        val enableIndex: Boolean,
+    )
+
+    /** Pushes a refresh to [IndexNotesWidget] whenever its rendered content, the
+     *  signed-in user, or the Index toggle changes. `updatePeriodMillis` in the
+     *  provider XML is only a best-effort fallback. */
+    @OptIn(FlowPreview::class)
+    private fun monitorIndexNotesWidget() {
+        val authUser = flow {
+            emit(Firebase.auth.currentUser)
+            Firebase.auth.authStateChanged.collect { emit(it) }
+        }
+        combine(
+            itemRepo.getAllFlow().debounce(500), // coalesce write bursts; auth/config pass through
+            authUser,
+            coreConfigHolder.config.map { it.enableIndex }.distinctUntilChanged(),
+        ) { items, user, enableIndex ->
+            val rows = recentNotesAndTodos(items)
+            WidgetRenderState(widgetRenderFingerprint(rows), rows.size, user?.uid, enableIndex)
+        }
+            .distinctUntilChanged()
+            .onEach { state ->
+                try {
+                    IndexNotesWidget().updateAll(context)
+                    logger.d { "Index widget refreshed: itemCount=${state.itemCount} enableIndex=${state.enableIndex}" }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.w(e) { "Index widget refresh failed" }
+                }
+            }
+            .launchIn(GlobalScope)
+    }
 
     actual fun requiredRuntimePermissions(): Set<Permission> = buildSet {
         addAll(setOf(

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
@@ -47,10 +50,19 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
 
     // Mirrors the in-app feed: local Room data, gated on enableIndex only (the feed
     // itself never gates on sign-in — notes/to-dos are created locally and sync later).
+    //
+    // Data is collected INSIDE the composition: a Glance session can stay alive for
+    // tens of seconds, and update()/updateAll() only recomposes it — provideGlance is
+    // not re-run — so a one-shot snapshot taken here would render stale for the
+    // session's lifetime. The .first() snapshot only seeds the initial frame.
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        val enableIndex = get<CoreConfigHolder>().config.value.enableIndex
-        val rows = if (enableIndex) recentNotesAndTodos(get<ItemRepository>().getAllFlow().first()) else emptyList()
+        val config = get<CoreConfigHolder>().config
+        val itemsFlow = get<ItemRepository>().getAllFlow()
+        val initialItems = itemsFlow.first()
         provideContent {
+            val enableIndex = config.collectAsState().value.enableIndex
+            val items by itemsFlow.collectAsState(initialItems)
+            val rows = remember(items) { recentNotesAndTodos(items) }
             GlanceTheme(ColorProviders(light = lightScheme, dark = greyScheme)) {
                 if (enableIndex) Content(context, rows) else Message(context, "Turn on Index to see your notes")
             }

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -64,6 +64,7 @@ private object W {
     private fun both(pick: (IndexColors) -> androidx.compose.ui.graphics.Color) =
         ColorProvider(day = pick(IndexColors.Light), night = pick(IndexColors.Dark))
     val surface = both { it.surface }
+    val card = both { it.surfaceContainerLow }
     val ink = both { it.onSurface }
     val meta = both { it.onSurfaceVariant }
     val outline = both { it.outline }
@@ -138,12 +139,11 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
             )
             return
         }
-        val first = rows.first()
-        LazyColumn(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
+        // Rows as cards: 4 dp gaps, 10 dp side margin, so five still fit at 3×3.
+        LazyColumn(modifier = GlanceModifier.fillMaxWidth().defaultWeight().padding(horizontal = 10.dp)) {
             items(rows) { item ->
-                Column(modifier = GlanceModifier.fillMaxWidth()) {
-                    if (item !== first) Box(GlanceModifier.fillMaxWidth().height(1.dp).background(W.divider)) {}
-                    RowLine(context, item, titles, now)
+                Column(modifier = GlanceModifier.fillMaxWidth().padding(top = if (item === rows.first()) 8.dp else 4.dp)) {
+                    RowCard(context, item, titles, now)
                 }
             }
         }
@@ -159,17 +159,18 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
     }
 
     @Composable
-    private fun RowLine(context: Context, item: CachedItem, titles: Map<String, String>, now: Instant) {
+    private fun RowCard(context: Context, item: CachedItem, titles: Map<String, String>, now: Instant) {
         val todo = item.isWidgetTodo()
         val label = widgetRowLabel(item, titles, now)
         val meta = if (todo) label else "$label · ${relativeTime(item.updatedAt, now)}"
         val metaColor = if (todo && label != "To-do") W.red else W.meta
         Row(
-            modifier = GlanceModifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 7.dp)
+            modifier = GlanceModifier.fillMaxWidth().background(W.card).cornerRadius(12.dp)
+                .padding(horizontal = 10.dp, vertical = 6.dp)
                 .clickable(actionStartActivity(launchIntent(context, RingRoutes.objectDeepLink(item.firestoreId)))),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Glyph(if (todo) W.red else W.outline)
+            Glyph(if (todo) W.red else W.outline, fill = W.card)
             Spacer(GlanceModifier.width(10.dp))
             Column {
                 Text(item.displayTitle, maxLines = 1, style = TextStyle(color = W.ink, fontSize = 14.5.sp, fontWeight = FontWeight.Medium))
@@ -178,12 +179,12 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
         }
     }
 
-    /** Hollow 13 dp circle drawn as a ring-coloured box with a surface-coloured box inside
+    /** Hollow 13 dp circle drawn as a ring-coloured box with a [fill]-coloured box inside
      *  (Glance has no border modifier). Red ring = to-do, outline ring = note. */
     @Composable
-    private fun Glyph(ring: ColorProvider) {
+    private fun Glyph(ring: ColorProvider, fill: ColorProvider) {
         Box(GlanceModifier.size(13.dp).background(ring).cornerRadius(7.dp), contentAlignment = Alignment.Center) {
-            Box(GlanceModifier.size(10.dp).background(W.surface).cornerRadius(5.dp)) {}
+            Box(GlanceModifier.size(10.dp).background(fill).cornerRadius(5.dp)) {}
         }
     }
 

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -33,7 +33,6 @@ import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
-import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
@@ -72,7 +71,6 @@ private object W {
     val ink = both { it.onSurface }
     val meta = both { it.onSurfaceVariant }
     val outline = both { it.outline }
-    val divider = both { it.outlineVariant }
     val red = ColorProvider(IndexColors.Light.primary)
     val onRed = ColorProvider(IndexColors.Light.onPrimary)
 }

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -1,0 +1,124 @@
+package coredevices.ring.glance
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.items
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.material3.ColorProviders
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import coredevices.ring.data.entity.room.indexfeed.CachedItem
+import coredevices.ring.data.entity.room.indexfeed.displayTitle
+import coredevices.ring.data.entity.room.indexfeed.recentNotesAndTodos
+import coredevices.ring.data.entity.room.indexfeed.widgetRowSubtitle
+import coredevices.ring.database.room.repository.ItemRepository
+import coredevices.ring.service.indexfeed.DefaultListsBootstrap.Companion.LIST_TODOS_ID
+import coredevices.ring.ui.navigation.RingRoutes
+import coredevices.util.CoreConfigHolder
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.auth.auth
+import kotlinx.coroutines.flow.first
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
+import theme.greyScheme
+import theme.lightScheme
+
+/** Home-screen widget listing the most recent Index notes and to-dos.
+ *  Instantiated by Glance (not Koin), so dependencies come via [KoinComponent]. */
+class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val enableIndex = get<CoreConfigHolder>().config.value.enableIndex
+        val signedIn = Firebase.auth.currentUser != null
+        val rows = if (enableIndex && signedIn) recentNotesAndTodos(get<ItemRepository>().getAllFlow().first()) else emptyList()
+        provideContent {
+            GlanceTheme(ColorProviders(light = lightScheme, dark = greyScheme)) {
+                when {
+                    !enableIndex -> Message(context, "Turn on Index to see your notes")
+                    !signedIn -> Message(context, "Sign in to see your notes")
+                    else -> Content(context, rows)
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun Message(context: Context, text: String) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize()
+                .background(GlanceTheme.colors.surface)
+                .padding(12.dp)
+                .clickable(actionStartActivity(launchIntent(context, null))),
+        ) {
+            Text(text, style = TextStyle(color = GlanceTheme.colors.onSurface))
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, rows: List<CachedItem>) {
+        Column(modifier = GlanceModifier.fillMaxSize().background(GlanceTheme.colors.surface).padding(12.dp)) {
+            Row(modifier = GlanceModifier.fillMaxWidth()) {
+                HeaderLink(context, "Notes", RingRoutes.allListsDeepLink())
+                Spacer(GlanceModifier.width(16.dp))
+                HeaderLink(context, "To-dos", RingRoutes.objectDeepLink(LIST_TODOS_ID))
+            }
+            if (rows.isEmpty()) {
+                Text(
+                    "Nothing yet — tap to add",
+                    modifier = GlanceModifier.padding(top = 8.dp)
+                        .clickable(actionStartActivity(launchIntent(context, RingRoutes.allListsDeepLink()))),
+                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant),
+                )
+                return@Column
+            }
+            LazyColumn(modifier = GlanceModifier.fillMaxWidth()) {
+                items(rows, itemId = { it.firestoreId.hashCode().toLong() }) { item ->
+                    Column(
+                        modifier = GlanceModifier.fillMaxWidth().padding(vertical = 6.dp)
+                            .clickable(actionStartActivity(launchIntent(context, RingRoutes.objectDeepLink(item.firestoreId)))),
+                    ) {
+                        Text(item.displayTitle, maxLines = 1, style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 14.sp))
+                        Text(widgetRowSubtitle(item), maxLines = 1, style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp))
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun HeaderLink(context: Context, label: String, deepLink: String) {
+        Text(
+            label,
+            modifier = GlanceModifier.clickable(actionStartActivity(launchIntent(context, deepLink))),
+            style = TextStyle(color = GlanceTheme.colors.primary, fontWeight = FontWeight.Bold, fontSize = 14.sp),
+        )
+    }
+
+    /** Same explicit-component launch as [VoiceWidget]; a null [deepLink] is a bare app launch. */
+    private fun launchIntent(context: Context, deepLink: String?): Intent =
+        Intent(context, Class.forName("coredevices.coreapp.MainActivity")).apply {
+            deepLink?.let { data = Uri.parse(it) }
+            action = Intent.ACTION_VIEW
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+}

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -35,8 +35,6 @@ import coredevices.ring.database.room.repository.ItemRepository
 import coredevices.ring.service.indexfeed.DefaultListsBootstrap.Companion.LIST_TODOS_ID
 import coredevices.ring.ui.navigation.RingRoutes
 import coredevices.util.CoreConfigHolder
-import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.auth.auth
 import kotlinx.coroutines.flow.first
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -47,17 +45,14 @@ import theme.lightScheme
  *  Instantiated by Glance (not Koin), so dependencies come via [KoinComponent]. */
 class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
 
+    // Mirrors the in-app feed: local Room data, gated on enableIndex only (the feed
+    // itself never gates on sign-in — notes/to-dos are created locally and sync later).
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val enableIndex = get<CoreConfigHolder>().config.value.enableIndex
-        val signedIn = Firebase.auth.currentUser != null
-        val rows = if (enableIndex && signedIn) recentNotesAndTodos(get<ItemRepository>().getAllFlow().first()) else emptyList()
+        val rows = if (enableIndex) recentNotesAndTodos(get<ItemRepository>().getAllFlow().first()) else emptyList()
         provideContent {
             GlanceTheme(ColorProviders(light = lightScheme, dark = greyScheme)) {
-                when {
-                    !enableIndex -> Message(context, "Turn on Index to see your notes")
-                    !signedIn -> Message(context, "Sign in to see your notes")
-                    else -> Content(context, rows)
-                }
+                if (enableIndex) Content(context, rows) else Message(context, "Turn on Index to see your notes")
             }
         }
     }

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -91,8 +91,9 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
                 )
                 return@Column
             }
-            LazyColumn(modifier = GlanceModifier.fillMaxWidth()) {
-                items(rows, itemId = { it.firestoreId.hashCode().toLong() }) { item ->
+            // defaultWeight(): take the height left under the header so the list scrolls instead of clipping.
+            LazyColumn(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
+                items(rows) { item ->
                     Column(
                         modifier = GlanceModifier.fillMaxWidth().padding(vertical = 6.dp)
                             .clickable(actionStartActivity(launchIntent(context, RingRoutes.objectDeepLink(item.firestoreId)))),

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package coredevices.ring.glance
 
 import android.content.Context
@@ -11,116 +13,181 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
-import androidx.glance.GlanceTheme
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.lazy.LazyColumn
 import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
+import androidx.glance.color.ColorProvider
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
 import androidx.glance.layout.Column
+import androidx.glance.layout.ColumnScope
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.size
 import androidx.glance.layout.width
-import androidx.glance.material3.ColorProviders
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
 import coredevices.ring.data.entity.room.indexfeed.CachedItem
+import coredevices.ring.data.entity.room.indexfeed.WidgetCounts
 import coredevices.ring.data.entity.room.indexfeed.displayTitle
+import coredevices.ring.data.entity.room.indexfeed.isWidgetTodo
 import coredevices.ring.data.entity.room.indexfeed.recentNotesAndTodos
-import coredevices.ring.data.entity.room.indexfeed.widgetRowSubtitle
+import coredevices.ring.data.entity.room.indexfeed.relativeTime
+import coredevices.ring.data.entity.room.indexfeed.widgetCounts
+import coredevices.ring.data.entity.room.indexfeed.widgetRowLabel
 import coredevices.ring.database.room.repository.ItemRepository
+import coredevices.ring.database.room.repository.ListRepository
 import coredevices.ring.service.indexfeed.DefaultListsBootstrap.Companion.LIST_TODOS_ID
 import coredevices.ring.ui.navigation.RingRoutes
+import coredevices.ring.ui.theme.IndexColors
 import coredevices.util.CoreConfigHolder
 import kotlinx.coroutines.flow.first
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
-import theme.greyScheme
-import theme.lightScheme
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
-/** Home-screen widget listing the most recent Index notes and to-dos.
- *  Instantiated by Glance (not Koin), so dependencies come via [KoinComponent]. */
+/** Index theme tokens as day/night providers so the widget matches the feed in both modes. */
+private object W {
+    private fun both(pick: (IndexColors) -> androidx.compose.ui.graphics.Color) =
+        ColorProvider(day = pick(IndexColors.Light), night = pick(IndexColors.Dark))
+    val surface = both { it.surface }
+    val ink = both { it.onSurface }
+    val meta = both { it.onSurfaceVariant }
+    val outline = both { it.outline }
+    val divider = both { it.outlineVariant }
+    val red = ColorProvider(IndexColors.Light.primary)
+    val onRed = ColorProvider(IndexColors.Light.onPrimary)
+}
+
+/** Home-screen widget: a Pebble-red band with today's counts over the most recent Index
+ *  notes and to-dos. Instantiated by Glance (not Koin), so dependencies come via [KoinComponent].
+ *
+ *  Data is collected INSIDE the composition: a Glance session can stay alive for tens of
+ *  seconds and update()/updateAll() only recomposes it — provideGlance is not re-run — so a
+ *  one-shot snapshot here would render stale for the session's lifetime. The .first() reads
+ *  only seed the initial frame. Mirrors the in-app feed: local Room data, gated on
+ *  enableIndex only (the feed never gates on sign-in). */
 class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
 
-    // Mirrors the in-app feed: local Room data, gated on enableIndex only (the feed
-    // itself never gates on sign-in — notes/to-dos are created locally and sync later).
-    //
-    // Data is collected INSIDE the composition: a Glance session can stay alive for
-    // tens of seconds, and update()/updateAll() only recomposes it — provideGlance is
-    // not re-run — so a one-shot snapshot taken here would render stale for the
-    // session's lifetime. The .first() snapshot only seeds the initial frame.
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val config = get<CoreConfigHolder>().config
         val itemsFlow = get<ItemRepository>().getAllFlow()
+        val listsFlow = get<ListRepository>().getAllFlow()
         val initialItems = itemsFlow.first()
+        val initialLists = listsFlow.first()
         provideContent {
             val enableIndex = config.collectAsState().value.enableIndex
             val items by itemsFlow.collectAsState(initialItems)
+            val lists by listsFlow.collectAsState(initialLists)
+            val titles = remember(lists) { lists.associate { it.firestoreId to it.displayTitle } }
             val rows = remember(items) { recentNotesAndTodos(items) }
-            GlanceTheme(ColorProviders(light = lightScheme, dark = greyScheme)) {
-                if (enableIndex) Content(context, rows) else Message(context, "Turn on Index to see your notes")
+            val counts = remember(items) { widgetCounts(items) }
+            Column(modifier = GlanceModifier.fillMaxSize().background(W.surface).cornerRadius(20.dp)) {
+                if (enableIndex) Banner(context, rows, counts, titles, Clock.System.now())
+                else Message(context, "Turn on Index to see your notes")
             }
         }
     }
 
     @Composable
     private fun Message(context: Context, text: String) {
-        Column(
-            modifier = GlanceModifier.fillMaxSize()
-                .background(GlanceTheme.colors.surface)
-                .padding(12.dp)
+        Text(
+            text,
+            modifier = GlanceModifier.fillMaxWidth().padding(16.dp)
                 .clickable(actionStartActivity(launchIntent(context, null))),
-        ) {
-            Text(text, style = TextStyle(color = GlanceTheme.colors.onSurface))
-        }
+            style = TextStyle(color = W.meta, fontSize = 13.sp),
+        )
     }
 
     @Composable
-    private fun Content(context: Context, rows: List<CachedItem>) {
-        Column(modifier = GlanceModifier.fillMaxSize().background(GlanceTheme.colors.surface).padding(12.dp)) {
-            Row(modifier = GlanceModifier.fillMaxWidth()) {
-                HeaderLink(context, "Notes", RingRoutes.allListsDeepLink())
-                Spacer(GlanceModifier.width(16.dp))
-                HeaderLink(context, "To-dos", RingRoutes.objectDeepLink(LIST_TODOS_ID))
+    private fun ColumnScope.Banner(context: Context, rows: List<CachedItem>, counts: WidgetCounts, titles: Map<String, String>, now: Instant) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth().background(W.red).padding(horizontal = 16.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            Text(
+                "Index",
+                modifier = GlanceModifier.clickable(actionStartActivity(launchIntent(context, null))),
+                style = TextStyle(color = W.onRed, fontSize = 15.sp, fontWeight = FontWeight.Bold),
+            )
+            Spacer(GlanceModifier.defaultWeight())
+            Column(horizontalAlignment = Alignment.End) {
+                CountLine(context, plural(counts.todos, "to-do"), RingRoutes.objectDeepLink(LIST_TODOS_ID))
+                CountLine(context, plural(counts.notes, "note"), RingRoutes.allListsDeepLink())
             }
-            if (rows.isEmpty()) {
-                Text(
-                    "Nothing yet — tap to add",
-                    modifier = GlanceModifier.padding(top = 8.dp)
-                        .clickable(actionStartActivity(launchIntent(context, RingRoutes.allListsDeepLink()))),
-                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant),
-                )
-                return@Column
-            }
-            // defaultWeight(): take the height left under the header so the list scrolls instead of clipping.
-            LazyColumn(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
-                items(rows) { item ->
-                    Column(
-                        modifier = GlanceModifier.fillMaxWidth().padding(vertical = 6.dp)
-                            .clickable(actionStartActivity(launchIntent(context, RingRoutes.objectDeepLink(item.firestoreId)))),
-                    ) {
-                        Text(item.displayTitle, maxLines = 1, style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 14.sp))
-                        Text(widgetRowSubtitle(item), maxLines = 1, style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp))
-                    }
+        }
+        if (rows.isEmpty()) {
+            Text(
+                "Nothing yet — tap to add",
+                modifier = GlanceModifier.fillMaxWidth().padding(16.dp)
+                    .clickable(actionStartActivity(launchIntent(context, RingRoutes.allListsDeepLink()))),
+                style = TextStyle(color = W.meta, fontSize = 13.sp),
+            )
+            return
+        }
+        val first = rows.first()
+        LazyColumn(modifier = GlanceModifier.fillMaxWidth().defaultWeight()) {
+            items(rows) { item ->
+                Column(modifier = GlanceModifier.fillMaxWidth()) {
+                    if (item !== first) Box(GlanceModifier.fillMaxWidth().height(1.dp).background(W.divider)) {}
+                    RowLine(context, item, titles, now)
                 }
             }
         }
     }
 
     @Composable
-    private fun HeaderLink(context: Context, label: String, deepLink: String) {
+    private fun CountLine(context: Context, text: String, deepLink: String) {
         Text(
-            label,
+            text,
             modifier = GlanceModifier.clickable(actionStartActivity(launchIntent(context, deepLink))),
-            style = TextStyle(color = GlanceTheme.colors.primary, fontWeight = FontWeight.Bold, fontSize = 14.sp),
+            style = TextStyle(color = W.onRed, fontSize = 11.5.sp, fontWeight = FontWeight.Medium),
         )
     }
+
+    @Composable
+    private fun RowLine(context: Context, item: CachedItem, titles: Map<String, String>, now: Instant) {
+        val todo = item.isWidgetTodo()
+        val label = widgetRowLabel(item, titles, now)
+        val meta = if (todo) label else "$label · ${relativeTime(item.updatedAt, now)}"
+        val metaColor = if (todo && label != "To-do") W.red else W.meta
+        Row(
+            modifier = GlanceModifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 7.dp)
+                .clickable(actionStartActivity(launchIntent(context, RingRoutes.objectDeepLink(item.firestoreId)))),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Glyph(if (todo) W.red else W.outline)
+            Spacer(GlanceModifier.width(10.dp))
+            Column {
+                Text(item.displayTitle, maxLines = 1, style = TextStyle(color = W.ink, fontSize = 14.5.sp, fontWeight = FontWeight.Medium))
+                Text(meta, maxLines = 1, style = TextStyle(color = metaColor, fontSize = 11.5.sp, fontWeight = if (metaColor === W.red) FontWeight.Medium else FontWeight.Normal))
+            }
+        }
+    }
+
+    /** Hollow 13 dp circle drawn as a ring-coloured box with a surface-coloured box inside
+     *  (Glance has no border modifier). Red ring = to-do, outline ring = note. */
+    @Composable
+    private fun Glyph(ring: ColorProvider) {
+        Box(GlanceModifier.size(13.dp).background(ring).cornerRadius(7.dp), contentAlignment = Alignment.Center) {
+            Box(GlanceModifier.size(10.dp).background(W.surface).cornerRadius(5.dp)) {}
+        }
+    }
+
+    private fun plural(n: Int, word: String) = "$n $word${if (n == 1) "" else "s"}"
 
     /** Same explicit-component launch as [VoiceWidget]; a null [deepLink] is a bare app launch. */
     private fun launchIntent(context: Context, deepLink: String?): Intent =

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidget.kt
@@ -11,8 +11,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.glance.ColorFilter
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.action.actionStartActivity
@@ -38,6 +41,7 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import coredevices.ring.R
 import coredevices.ring.data.entity.room.indexfeed.CachedItem
 import coredevices.ring.data.entity.room.indexfeed.WidgetCounts
 import coredevices.ring.data.entity.room.indexfeed.displayTitle
@@ -170,7 +174,7 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
                 .clickable(actionStartActivity(launchIntent(context, RingRoutes.objectDeepLink(item.firestoreId)))),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Glyph(if (todo) W.red else W.outline, fill = W.card)
+            if (todo) Ring(W.red, fill = W.card) else NotePad()
             Spacer(GlanceModifier.width(10.dp))
             Column {
                 Text(item.displayTitle, maxLines = 1, style = TextStyle(color = W.ink, fontSize = 14.5.sp, fontWeight = FontWeight.Medium))
@@ -179,13 +183,24 @@ class IndexNotesWidget : GlanceAppWidget(), KoinComponent {
         }
     }
 
-    /** Hollow 13 dp circle drawn as a ring-coloured box with a [fill]-coloured box inside
-     *  (Glance has no border modifier). Red ring = to-do, outline ring = note. */
+    /** Hollow 13 dp circle (a to-do's unchecked box) drawn as a ring-coloured box with a
+     *  [fill]-coloured box inside — Glance has no border modifier. */
     @Composable
-    private fun Glyph(ring: ColorProvider, fill: ColorProvider) {
+    private fun Ring(ring: ColorProvider, fill: ColorProvider) {
         Box(GlanceModifier.size(13.dp).background(ring).cornerRadius(7.dp), contentAlignment = Alignment.Center) {
             Box(GlanceModifier.size(10.dp).background(fill).cornerRadius(5.dp)) {}
         }
+    }
+
+    /** Notepad glyph for note rows, tinted with the outline colour. */
+    @Composable
+    private fun NotePad() {
+        Image(
+            provider = ImageProvider(R.drawable.ic_widget_note),
+            contentDescription = null,
+            modifier = GlanceModifier.size(15.dp),
+            colorFilter = ColorFilter.tint(W.outline),
+        )
     }
 
     private fun plural(n: Int, word: String) = "$n $word${if (n == 1) "" else "s"}"

--- a/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidgetReceiver.kt
+++ b/experimental/src/androidMain/kotlin/coredevices/ring/glance/IndexNotesWidgetReceiver.kt
@@ -1,0 +1,9 @@
+package coredevices.ring.glance
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+class IndexNotesWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget
+        get() = IndexNotesWidget()
+}

--- a/experimental/src/androidMain/res/drawable/ic_widget_note.xml
+++ b/experimental/src/androidMain/res/drawable/ic_widget_note.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Notepad glyph for the Index home-screen widget's note rows (Material "description"). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M14,2H6C4.9,2 4,2.9 4,4v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8L14,2zM16,18H8v-2h8V18zM16,14H8v-2h8V14zM13,9V3.5L18.5,9H13z" />
+</vector>

--- a/experimental/src/androidMain/res/values/strings.xml
+++ b/experimental/src/androidMain/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="voice_widget_description">Voice Note</string>
+    <string name="index_notes_widget_description">Notes &amp; To-dos</string>
     <string name="share_target_index_note">Index note</string>
     <string name="share_target_index_reminder">Index reminder</string>
     <string name="share_to_index_note_done">Note added to Index</string>

--- a/experimental/src/androidMain/res/xml/index_notes_widget_info.xml
+++ b/experimental/src/androidMain/res/xml/index_notes_widget_info.xml
@@ -1,0 +1,13 @@
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:minWidth="180dp"
+                    android:minHeight="180dp"
+                    android:targetCellWidth="3"
+                    android:targetCellHeight="2"
+                    android:maxResizeWidth="360dp"
+                    android:maxResizeHeight="360dp"
+                    android:updatePeriodMillis="1800000"
+                    android:description="@string/index_notes_widget_description"
+                    android:resizeMode="horizontal|vertical"
+                    android:widgetCategory="home_screen"
+                    android:widgetFeatures="reconfigurable|configuration_optional">
+</appwidget-provider>

--- a/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodos.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodos.kt
@@ -1,0 +1,32 @@
+@file:OptIn(ExperimentalTime::class)
+
+package coredevices.ring.data.entity.room.indexfeed
+
+import coredevices.ring.service.indexfeed.DefaultListsBootstrap.Companion.LIST_TODOS_ID
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
+
+/** Todo = membership in the system Todos list, matching `IndexFeedViewModel`. */
+private fun CachedItem.isWidgetTodo(): Boolean = parentListIds().contains(LIST_TODOS_ID)
+
+/** Rows for the Android "Notes & To-dos" home-screen widget: newest first, ties by id. */
+fun recentNotesAndTodos(items: List<CachedItem>, limit: Int = 5): List<CachedItem> {
+    require(limit > 0) { "limit must be > 0, was $limit" }
+    return items.asSequence()
+        .filter { !it.deleted && !it.locked && !it.done }
+        .filter { it.isWidgetTodo() || it.kind == "note" }
+        .sortedWith(compareByDescending<CachedItem> { it.createdAt }.thenBy { it.firestoreId })
+        .take(limit)
+        .toList()
+}
+
+fun widgetRowSubtitle(item: CachedItem): String {
+    if (!item.isWidgetTodo()) return "Note"
+    val due = item.dueAt ?: return "To-do"
+    return "Due ${due.toLocalDateTime(TimeZone.currentSystemDefault()).date}"
+}
+
+/** What the widget actually renders per row; used to skip no-op refreshes. */
+fun widgetRenderFingerprint(rows: List<CachedItem>): List<Triple<String, String, String>> =
+    rows.map { Triple(it.firestoreId, it.displayTitle, widgetRowSubtitle(it)) }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodos.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodos.kt
@@ -3,30 +3,85 @@
 package coredevices.ring.data.entity.room.indexfeed
 
 import coredevices.ring.service.indexfeed.DefaultListsBootstrap.Companion.LIST_TODOS_ID
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /** Todo = membership in the system Todos list, matching `IndexFeedViewModel`. */
-private fun CachedItem.isWidgetTodo(): Boolean = parentListIds().contains(LIST_TODOS_ID)
+fun CachedItem.isWidgetTodo(): Boolean = parentListIds().contains(LIST_TODOS_ID)
+
+private fun CachedItem.isWidgetVisible(): Boolean =
+    !deleted && !locked && !done && (isWidgetTodo() || kind == "note")
 
 /** Rows for the Android "Notes & To-dos" home-screen widget: newest first, ties by id. */
 fun recentNotesAndTodos(items: List<CachedItem>, limit: Int = 5): List<CachedItem> {
     require(limit > 0) { "limit must be > 0, was $limit" }
     return items.asSequence()
-        .filter { !it.deleted && !it.locked && !it.done }
-        .filter { it.isWidgetTodo() || it.kind == "note" }
+        .filter { it.isWidgetVisible() }
         .sortedWith(compareByDescending<CachedItem> { it.createdAt }.thenBy { it.firestoreId })
         .take(limit)
         .toList()
 }
 
-fun widgetRowSubtitle(item: CachedItem): String {
-    if (!item.isWidgetTodo()) return "Note"
-    val due = item.dueAt ?: return "To-do"
-    return "Due ${due.toLocalDateTime(TimeZone.currentSystemDefault()).date}"
+data class WidgetCounts(val todos: Int, val notes: Int)
+
+/** To-dos vs notes among the items the widget would consider (before the row cap). */
+fun widgetCounts(items: List<CachedItem>): WidgetCounts {
+    val visible = items.filter { it.isWidgetVisible() }
+    val todos = visible.count { it.isWidgetTodo() }
+    return WidgetCounts(todos = todos, notes = visible.size - todos)
 }
 
-/** What the widget actually renders per row; used to skip no-op refreshes. */
-fun widgetRenderFingerprint(rows: List<CachedItem>): List<Triple<String, String, String>> =
-    rows.map { Triple(it.firestoreId, it.displayTitle, widgetRowSubtitle(it)) }
+private fun LocalDate.dayMonth(): String =
+    "$day ${month.name.take(3).lowercase().replaceFirstChar { it.uppercase() }}"
+
+/** "now" / "5 min" / "3 h" / "Yesterday" / "1 Sep". */
+fun relativeTime(at: Instant, now: Instant, tz: TimeZone = TimeZone.currentSystemDefault()): String {
+    val elapsed = now - at
+    if (elapsed < 1.minutes) return "now"
+    if (elapsed < 1.hours) return "${elapsed.inWholeMinutes} min"
+    val today = now.toLocalDateTime(tz).date
+    val date = at.toLocalDateTime(tz).date
+    return when {
+        date == today -> "${elapsed.inWholeHours} h"
+        date.toEpochDays() == today.toEpochDays() - 1 -> "Yesterday"
+        else -> date.dayMonth()
+    }
+}
+
+/** To-dos: "Due today" / "Due tomorrow" / "Due 15 Sep" / "Overdue" / "To-do".
+ *  Notes: the parent list's title, or "Note" when unfiled / unknown. */
+fun widgetRowLabel(
+    item: CachedItem,
+    listTitles: Map<String, String>,
+    now: Instant,
+    tz: TimeZone = TimeZone.currentSystemDefault(),
+): String {
+    if (item.isWidgetTodo()) {
+        val due = item.dueAt ?: return "To-do"
+        val today = now.toLocalDateTime(tz).date
+        val dueDate = due.toLocalDateTime(tz).date
+        return when {
+            dueDate.toEpochDays() < today.toEpochDays() -> "Overdue"
+            dueDate == today -> "Due today"
+            dueDate.toEpochDays() == today.toEpochDays() + 1 -> "Due tomorrow"
+            else -> "Due ${dueDate.dayMonth()}"
+        }
+    }
+    return item.parentListIds().firstNotNullOfOrNull { listTitles[it] } ?: "Note"
+}
+
+/** What the widget actually renders per row (title + label; relative time excluded so
+ *  the fingerprint doesn't churn every minute); used to skip no-op refreshes. */
+fun widgetRenderFingerprint(
+    rows: List<CachedItem>,
+    listTitles: Map<String, String> = emptyMap(),
+    now: Instant = Clock.System.now(),
+    tz: TimeZone = TimeZone.currentSystemDefault(),
+): List<Triple<String, String, String>> =
+    rows.map { Triple(it.firestoreId, it.displayTitle, widgetRowLabel(it, listTitles, now, tz)) }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/navigation/RingRoutes.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/navigation/RingRoutes.kt
@@ -77,6 +77,11 @@ object RingRoutes {
     const val RECORDING_DEEP_LINK_PATH = "recording"
     fun recordingDeepLink(recordingId: Long) =
         "pebblecore://$OBJECT_DEEP_LINK_HOST/$RECORDING_DEEP_LINK_PATH?$OBJECT_DEEP_LINK_ID_PARAM=$recordingId"
+
+    /** Deep link that opens [AllLists]. Used by the Android home-screen
+     *  widget's "Notes" header. Parsed by `CoreDeepLinkHandler`. */
+    const val ALL_LISTS_DEEP_LINK_PATH = "all-lists"
+    fun allListsDeepLink() = "pebblecore://$OBJECT_DEEP_LINK_HOST/$ALL_LISTS_DEEP_LINK_PATH"
 }
 
 /** Registers a ring destination inside [IndexThemeHost], so screens read

--- a/experimental/src/commonTest/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodosTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodosTest.kt
@@ -8,9 +8,13 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
 
 class RecentNotesAndTodosTest {
 
@@ -97,22 +101,6 @@ class RecentNotesAndTodosTest {
     }
 
     @Test
-    fun subtitleIsNoteForPlainNote() {
-        assertEquals("Note", widgetRowSubtitle(item("a")))
-    }
-
-    @Test
-    fun subtitleIsTodoForTodoMemberWithoutDueDate() {
-        assertEquals("To-do", widgetRowSubtitle(item("a", lists = LIST_TODOS_ID)))
-    }
-
-    @Test
-    fun subtitleStartsWithDueForTodoMemberWithDueDate() {
-        val subtitle = widgetRowSubtitle(item("a", lists = LIST_TODOS_ID, dueAt = Instant.fromEpochMilliseconds(0)))
-        assertTrue(subtitle.startsWith("Due "), subtitle)
-    }
-
-    @Test
     fun fingerprintChangesWhenMembershipFlipsSubtitle() {
         val asNote = item("a")
         val asTodo = item("a", lists = LIST_TODOS_ID)
@@ -124,6 +112,49 @@ class RecentNotesAndTodosTest {
         val untitled = item("a", title = "")
         assertEquals(listOf("a"), recentNotesAndTodos(listOf(untitled)).map { it.firestoreId })
         assertEquals(listOf(Triple("a", "", "Note")), widgetRenderFingerprint(listOf(untitled)))
+    }
+
+    // --- Banner widget: counts, row labels, relative time (all in UTC for determinism) ---
+
+    private val utc = TimeZone.UTC
+    private val now = Instant.parse("2026-09-06T10:00:00Z")
+
+    @Test
+    fun countsSplitTodosAndNotesAndSkipExcludedItems() {
+        val items = listOf(
+            item("t1", metadata = reminder, lists = LIST_TODOS_ID),
+            item("n1"), item("n2", lists = "yu"),
+            item("gone", deleted = true), item("done", done = true, lists = LIST_TODOS_ID),
+        )
+        assertEquals(WidgetCounts(todos = 1, notes = 2), widgetCounts(items))
+    }
+
+    @Test
+    fun relativeTimeBuckets() {
+        assertEquals("now", relativeTime(now - 30.seconds, now, utc))
+        assertEquals("5 min", relativeTime(now - 5.minutes, now, utc))
+        assertEquals("3 h", relativeTime(now - 3.hours, now, utc))
+        assertEquals("Yesterday", relativeTime(Instant.parse("2026-09-05T23:00:00Z"), now, utc))
+        assertEquals("1 Sep", relativeTime(Instant.parse("2026-09-01T09:00:00Z"), now, utc))
+    }
+
+    @Test
+    fun todoLabelReflectsDueDate() {
+        val lists = emptyMap<String, String>()
+        assertEquals("To-do", widgetRowLabel(item("a", lists = LIST_TODOS_ID), lists, now, utc))
+        assertEquals("Due today", widgetRowLabel(item("a", lists = LIST_TODOS_ID, dueAt = now + 2.hours), lists, now, utc))
+        assertEquals("Due tomorrow", widgetRowLabel(item("a", lists = LIST_TODOS_ID, dueAt = now + 1.days), lists, now, utc))
+        assertEquals("Due 15 Sep", widgetRowLabel(item("a", lists = LIST_TODOS_ID, dueAt = Instant.parse("2026-09-15T12:00:00Z")), lists, now, utc))
+        assertEquals("Overdue", widgetRowLabel(item("a", lists = LIST_TODOS_ID, dueAt = now - 2.days), lists, now, utc))
+    }
+
+    @Test
+    fun noteLabelIsParentListNameOrNote() {
+        val lists = mapOf("yu" to "yu", "notes_self" to "Notes to self")
+        assertEquals("yu", widgetRowLabel(item("a", lists = "yu"), lists, now, utc))
+        assertEquals("Notes to self", widgetRowLabel(item("a", lists = "notes_self"), lists, now, utc))
+        assertEquals("Note", widgetRowLabel(item("a"), lists, now, utc))
+        assertEquals("Note", widgetRowLabel(item("a", lists = "unknown_list"), lists, now, utc))
     }
 
     @Test

--- a/experimental/src/commonTest/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodosTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodosTest.kt
@@ -1,0 +1,128 @@
+@file:OptIn(ExperimentalTime::class)
+
+package coredevices.ring.data.entity.room.indexfeed
+
+import coredevices.indexai.data.entity.ItemDocument.ItemMetadata
+import coredevices.ring.service.indexfeed.DefaultListsBootstrap.Companion.LIST_TODOS_ID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+class RecentNotesAndTodosTest {
+
+    private fun item(
+        id: String,
+        createdAtMs: Long = 1_000,
+        metadata: ItemMetadata = ItemMetadata.Note,
+        lists: String = "",
+        title: String = "t-$id",
+        done: Boolean = false,
+        deleted: Boolean = false,
+        locked: Boolean = false,
+        dueAt: Instant? = null,
+    ) = CachedItem(
+        firestoreId = id,
+        createdAt = Instant.fromEpochMilliseconds(createdAtMs),
+        updatedAt = Instant.fromEpochMilliseconds(createdAtMs),
+        title = title,
+        metadata = metadata,
+        parentListIdsCsv = lists,
+        done = done,
+        deleted = deleted,
+        locked = locked,
+        dueAt = dueAt,
+    )
+
+    private val reminder = ItemMetadata.Reminder(repeat = "one_time", notification = "push")
+
+    @Test
+    fun excludesDeletedItems() {
+        val rows = recentNotesAndTodos(listOf(item("a", deleted = true), item("b")))
+        assertEquals(listOf("b"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun excludesLockedItems() {
+        val rows = recentNotesAndTodos(listOf(item("a", locked = true), item("b")))
+        assertEquals(listOf("b"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun excludesDoneItems() {
+        val rows = recentNotesAndTodos(listOf(item("a", done = true), item("b")))
+        assertEquals(listOf("b"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun includesNoteFiledUnderUserList() {
+        val rows = recentNotesAndTodos(listOf(item("a", lists = "some_user_list")))
+        assertEquals(listOf("a"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun includesTodoMemberRegardlessOfKind() {
+        val rows = recentNotesAndTodos(listOf(item("a", metadata = reminder, lists = LIST_TODOS_ID)))
+        assertEquals(listOf("a"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun excludesNonNoteKindsOutsideTodosList() {
+        val answer = item("a", metadata = ItemMetadata.Answer(question = "q"))
+        val reminderNotInTodos = item("b", metadata = reminder)
+        val rows = recentNotesAndTodos(listOf(answer, reminderNotInTodos, item("c")))
+        assertEquals(listOf("c"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun sortsNewestFirstThenByIdForTies() {
+        val rows = recentNotesAndTodos(
+            listOf(item("b", createdAtMs = 5), item("a", createdAtMs = 5), item("z", createdAtMs = 9)),
+        )
+        assertEquals(listOf("z", "a", "b"), rows.map { it.firestoreId })
+    }
+
+    @Test
+    fun truncatesToLimit() {
+        val rows = recentNotesAndTodos((1..7).map { item("i$it", createdAtMs = it.toLong()) }, limit = 5)
+        assertEquals(5, rows.size)
+    }
+
+    @Test
+    fun rejectsNonPositiveLimit() {
+        assertFailsWith<IllegalArgumentException> { recentNotesAndTodos(listOf(item("a")), limit = 0) }
+    }
+
+    @Test
+    fun subtitleIsNoteForPlainNote() {
+        assertEquals("Note", widgetRowSubtitle(item("a")))
+    }
+
+    @Test
+    fun subtitleIsTodoForTodoMemberWithoutDueDate() {
+        assertEquals("To-do", widgetRowSubtitle(item("a", lists = LIST_TODOS_ID)))
+    }
+
+    @Test
+    fun subtitleStartsWithDueForTodoMemberWithDueDate() {
+        val subtitle = widgetRowSubtitle(item("a", lists = LIST_TODOS_ID, dueAt = Instant.fromEpochMilliseconds(0)))
+        assertTrue(subtitle.startsWith("Due "), subtitle)
+    }
+
+    @Test
+    fun fingerprintChangesWhenMembershipFlipsSubtitle() {
+        val asNote = item("a")
+        val asTodo = item("a", lists = LIST_TODOS_ID)
+        assertNotEquals(widgetRenderFingerprint(listOf(asNote)), widgetRenderFingerprint(listOf(asTodo)))
+    }
+
+    @Test
+    fun fingerprintIgnoresFieldsThatAreNotRendered() {
+        val a = item("a", createdAtMs = 1)
+        val b = item("a", createdAtMs = 2)
+        assertEquals(widgetRenderFingerprint(listOf(a)), widgetRenderFingerprint(listOf(b)))
+    }
+}

--- a/experimental/src/commonTest/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodosTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/data/entity/room/indexfeed/RecentNotesAndTodosTest.kt
@@ -120,6 +120,13 @@ class RecentNotesAndTodosTest {
     }
 
     @Test
+    fun emptyTitleItemIsIncludedAndFingerprinted() {
+        val untitled = item("a", title = "")
+        assertEquals(listOf("a"), recentNotesAndTodos(listOf(untitled)).map { it.firestoreId })
+        assertEquals(listOf(Triple("a", "", "Note")), widgetRenderFingerprint(listOf(untitled)))
+    }
+
+    @Test
     fun fingerprintIgnoresFieldsThatAreNotRendered() {
         val a = item("a", createdAtMs = 1)
         val b = item("a", createdAtMs = 2)


### PR DESCRIPTION
## What

A Glance home-screen widget (Android only) for the Index feed: a Pebble-red band with live counts over the most recent notes and to-dos, in the app's own Index theme.

- **Band**: "Index" wordmark (opens the app), "N to-dos" opens the Todos list, "N notes" opens the lists grid via a new `pebblecore://deep-link/all-lists` (resolver added to `CoreDeepLinkHandler`, same shape as the object and recording resolvers). Counts come from the same predicate as the rows.
- **Rows** (5 most recent, each a `surfaceContainerLow` card, 12 dp radius, 4 dp gaps): notepad glyph for notes, hollow red ring for to-dos; title; meta line: `Due today` / `Due tomorrow` / `Due 15 Sep` / `Overdue` for to-dos, `<parent list> · <relative time>` for notes. Each row deep-links to its item.
- **Predicate** (`recentNotesAndTodos`): todo = membership in the system Todos list (matches `IndexFeedViewModel`), plus `kind == "note"`; excludes deleted, locked and done items; `createdAt` desc, `firestoreId` tiebreak.
- **Colours**: `IndexColors.Light` / `IndexColors.Dark` as day/night `ColorProvider`s, so no new hex values. Type is the system face.
- **Data**: collected with `collectAsState` inside `provideContent` (items, lists, `enableIndex`). A live Glance session only recomposes on `update()` and never re-runs `provideGlance`, so a snapshot taken there would go stale; the `.first()` reads only seed the first frame.
- **Refresh**: observer in `RingDelegate`'s `init {}` block, which runs at Koin construction and does not depend on the async `weatherFetcher`-gated `init()`. It combines items (debounced 500 ms), lists and `enableIndex`, deduped on a fingerprint of title + label (relative time excluded so it doesn't churn). `CancellationException` is rethrown. `updatePeriodMillis=30min` is a best-effort fallback.
- **States**: gated on `enableIndex` only, like the in-app feed (which never gates on sign-in). Receiver always enabled; "Turn on Index…" and the empty state are widget content.

## Tests / verification

- `experimental` host tests 323/323 (16 new in `RecentNotesAndTodosTest`: predicate, sort, cap, counts, relative time, due labels, list labels, fingerprint), `composeApp` 15/15 (+2 deep-link resolver tests). Written test-first.
- `:androidApp:assembleDebug` builds with the README's dummy `google-services.json`.
- Emulator (Pixel 6, API 35) and device (Pixel 10 Pro Fold, Android 17, Lawnchair): placement, render, live update while a Glance session is open, to-do row, row tap to `ObjectDetails`, refresh after a force-stop. Screenshots and the full verification log are on the fork PR, TechHQUSA/mobileapp#1.

## AI disclosure

Per CONTRIBUTING.md: the code and tests were written with Claude Code (Anthropic) as the coding assistant. The design was chosen from mockups by me, I tested each iteration on my own device, and I have reviewed the changes.

## Notes for reviewers

- Reads the same local Room tables as `IndexFeedScreen`, with the same (absent) auth gating. It shows what the feed shows, nothing more.
- Red text (`primary`) is 3.3:1 and meta grey 4.3:1 on the cream surface. Those are the app's own tokens, used the way the feed uses them; red meta is Medium weight. I can darken them in the widget only if you prefer.
- The launcher logs `AppWidgetHostView: Error inflating AppWidget` before the first update, same as `VoiceWidget`; `android:initialLayout="@layout/glance_default_loading_layout"` would silence it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
