### PR TITLE
feat(obsidian): make the prefix string to obsidian notes configurable

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianIntegration.kt
@@ -55,11 +55,18 @@ class ObsidianIntegration(
         return vault.hasAccess(handle)
     }
 
-    fun saveConfig(mode: ObsidianMode, targetNote: String, subfolder: String, customTag: String) {
+    fun saveConfig(
+        mode: ObsidianMode,
+        targetNote: String,
+        subfolder: String,
+        customTag: String,
+        appendPrefix: String = prefs.appendPrefix.value,
+    ) {
         prefs.setMode(mode)
         prefs.setTargetNote(ObsidianNoteFormatter.sanitizeSubfolder(targetNote))
         prefs.setSubfolder(subfolder)
         prefs.setCustomTag(ObsidianNoteFormatter.sanitizeTag(customTag))
+        prefs.setAppendPrefix(appendPrefix)
     }
 
     fun vaultDisplayName(): String? = prefs.vaultName.value
@@ -69,6 +76,7 @@ class ObsidianIntegration(
     fun currentTargetNote(): String = prefs.targetNote.value
     fun currentSubfolder(): String = prefs.subfolder.value
     fun currentCustomTag(): String = prefs.customTag.value
+    fun currentAppendPrefix(): String = prefs.appendPrefix.value
 
     /** Vault-relative paths of existing `.md` files for the "named note" suggestions (empty if no access). */
     suspend fun listNotes(): List<String> {
@@ -95,6 +103,7 @@ class ObsidianIntegration(
             targetNote = targetNote,
             subfolder = prefs.subfolder.value,
             customTag = prefs.customTag.value,
+            appendPrefix = prefs.appendPrefix.value,
         )
         val local = clock.now().toLocalDateTime(timeZone)
         val write = ObsidianNoteFormatter.plan(

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianNoteFormatter.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianNoteFormatter.kt
@@ -7,6 +7,7 @@ data class ObsidianConfig(
     val subfolder: String,
     /** Extra frontmatter tag for timestamped files, e.g. "fleeting". Blank = just "index". */
     val customTag: String = "",
+    val appendPrefix: String = ObsidianNoteFormatter.DEFAULT_APPEND_PREFIX,
 )
 
 /** A concrete filesystem action for one note. [fileName] may contain one subfolder segment. */
@@ -24,6 +25,7 @@ sealed interface ObsidianWrite {
 object ObsidianNoteFormatter {
 
     const val MAIN_NOTE_NAME = "Pebble Index.md"
+    const val DEFAULT_APPEND_PREFIX = "## YYYY-MM-DD HH:mm\\n\\n"
 
     fun plan(config: ObsidianConfig, content: String, year: Int, month: Int, day: Int, hour: Int, minute: Int): ObsidianWrite {
         val date = "$year-${pad2(month)}-${pad2(day)}"
@@ -37,9 +39,9 @@ object ObsidianNoteFormatter {
                 ObsidianWrite.NewFile(fileName, timestampedContent(isoMinute, content, sanitizeTag(config.customTag)))
             }
             ObsidianMode.MAIN_NOTE ->
-                ObsidianWrite.Append(MAIN_NOTE_NAME, appendBlock(date, hour, minute, content))
+                ObsidianWrite.Append(MAIN_NOTE_NAME, appendBlock(config.appendPrefix, date, hour, minute, content))
             ObsidianMode.NAMED_NOTE ->
-                ObsidianWrite.Append(withMdExtension(config.targetNote), appendBlock(date, hour, minute, content))
+                ObsidianWrite.Append(withMdExtension(config.targetNote), appendBlock(config.appendPrefix, date, hour, minute, content))
         }
     }
 
@@ -48,8 +50,13 @@ object ObsidianNoteFormatter {
         return "---\ncreated: $isoMinute\ntags: [$tags]\n---\n\n${content.trimEnd()}\n"
     }
 
-    private fun appendBlock(date: String, hour: Int, minute: Int, content: String): String =
-        "## $date ${pad2(hour)}:${pad2(minute)}\n\n${content.trimEnd()}\n"
+    private fun appendBlock(prefix: String, date: String, hour: Int, minute: Int, content: String): String {
+        val formattedPrefix = prefix
+            .replace("YYYY-MM-DD", date)
+            .replace("HH:mm", "${pad2(hour)}:${pad2(minute)}")
+            .replace("\\n", "\n")
+        return "$formattedPrefix${content.trimEnd()}\n"
+    }
 
     /** Concatenate [block] after [existing], guaranteeing exactly one blank line between them. */
     fun mergeAppend(existing: String?, block: String): String {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianPreferences.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianPreferences.kt
@@ -19,6 +19,7 @@ class ObsidianPreferences(private val settings: Settings) {
         private const val TARGET_NOTE_KEY = "obsidian_target_note"
         private const val SUBFOLDER_KEY = "obsidian_subfolder"
         private const val CUSTOM_TAG_KEY = "obsidian_custom_tag"
+        private const val APPEND_PREFIX_KEY = "obsidian_append_prefix"
     }
 
     private val _vaultHandle = MutableStateFlow(settings.getStringOrNull(HANDLE_KEY))
@@ -40,6 +41,11 @@ class ObsidianPreferences(private val settings: Settings) {
 
     private val _customTag = MutableStateFlow(settings.getStringOrNull(CUSTOM_TAG_KEY) ?: "")
     val customTag = _customTag.asStateFlow()
+
+    private val _appendPrefix = MutableStateFlow(
+        settings.getStringOrNull(APPEND_PREFIX_KEY) ?: ObsidianNoteFormatter.DEFAULT_APPEND_PREFIX
+    )
+    val appendPrefix = _appendPrefix.asStateFlow()
 
     fun setVault(handle: String, name: String) {
         settings.putString(HANDLE_KEY, handle)
@@ -68,6 +74,11 @@ class ObsidianPreferences(private val settings: Settings) {
         _customTag.value = tag
     }
 
+    fun setAppendPrefix(prefix: String) {
+        settings.putString(APPEND_PREFIX_KEY, prefix)
+        _appendPrefix.value = prefix
+    }
+
     fun clear() {
         settings.remove(HANDLE_KEY)
         settings.remove(NAME_KEY)
@@ -75,11 +86,13 @@ class ObsidianPreferences(private val settings: Settings) {
         settings.remove(TARGET_NOTE_KEY)
         settings.remove(SUBFOLDER_KEY)
         settings.remove(CUSTOM_TAG_KEY)
+        settings.remove(APPEND_PREFIX_KEY)
         _vaultHandle.value = null
         _vaultName.value = null
         _mode.value = ObsidianMode.TIMESTAMPED_FILES
         _targetNote.value = ""
         _subfolder.value = DEFAULT_SUBFOLDER
         _customTag.value = ""
+        _appendPrefix.value = ObsidianNoteFormatter.DEFAULT_APPEND_PREFIX
     }
 }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
@@ -462,6 +462,7 @@ fun ObsidianDialog(
     M3Dialog(
         onDismissRequest = onDismiss,
         title = { Text("Obsidian") },
+        scrollableContent = true,
         buttons = {
             TextButton(onClick = onDismiss) { Text("Cancel") }
             if (vaultName != null) {

--- a/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/ui/screens/settings/AddIntegration.kt
@@ -429,6 +429,7 @@ fun ObsidianDialog(
     var mode by remember { mutableStateOf(if (alreadyConfigured) integration.currentMode() else ObsidianMode.TIMESTAMPED_FILES) }
     var subfolder by remember { mutableStateOf(if (alreadyConfigured) integration.currentSubfolder().ifEmpty { ObsidianPreferences.DEFAULT_SUBFOLDER } else ObsidianPreferences.DEFAULT_SUBFOLDER) }
     var customTag by remember { mutableStateOf(if (alreadyConfigured) integration.currentCustomTag() else "") }
+    var appendPrefix by remember { mutableStateOf(integration.currentAppendPrefix()) }
     var notes by remember { mutableStateOf<List<String>>(emptyList()) }
     var notePath by remember { mutableStateOf(if (alreadyConfigured) integration.currentTargetNote() else "") }
 
@@ -475,6 +476,7 @@ fun ObsidianDialog(
                                 targetNote = notePath,
                                 subfolder = subfolder,
                                 customTag = customTag,
+                                appendPrefix = appendPrefix,
                             )
                             if (!alreadyConfigured) {
                                 preferences.setNoteProvider(NoteProvider.Obsidian)
@@ -529,6 +531,21 @@ fun ObsidianDialog(
                     notePath = notePath,
                     onNotePathChange = { notePath = it },
                 )
+                if (mode != ObsidianMode.TIMESTAMPED_FILES) {
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = appendPrefix,
+                        onValueChange = { appendPrefix = it },
+                        label = { Text("Text before each note") },
+                        placeholder = { Text("[[YYYY-MM-DD]] HH:mm: ") },
+                        supportingText = {
+                            Text("YYYY-MM-DD = date, HH:mm = time. Use \\n or Enter for a newline. Note text follows exactly; include any spaces or bullets. Leave empty for note text only.")
+                        },
+                        minLines = 2,
+                        maxLines = 4,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
             if (error != null) {
                 Text(

--- a/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianIntegrationTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianIntegrationTest.kt
@@ -117,6 +117,25 @@ class ObsidianIntegrationTest {
     }
 
     @Test
+    fun savedAppendPrefixIsUsedAfterReload() = runTest {
+        val vault = FakeVault()
+        vault.files["Inbox.md"] = "existing"
+        val settings = MapSettings()
+        val prefs = ObsidianPreferences(settings).apply { setVault("h", "vault") }
+        integration(vault, prefs).saveConfig(
+            mode = ObsidianMode.NAMED_NOTE,
+            targetNote = "Inbox",
+            subfolder = "",
+            customTag = "",
+            appendPrefix = "- [[YYYY-MM-DD]] HH:mm: ",
+        )
+
+        integration(vault, ObsidianPreferences(settings)).createNote("buy milk")
+
+        assertEquals("existing\n\n- [[2026-06-18]] 14:05: buy milk\n", vault.files["Inbox.md"])
+    }
+
+    @Test
     fun namedNoteModeAppendsToTarget() = runTest {
         val vault = FakeVault()
         val prefs = ObsidianPreferences(MapSettings()).apply {

--- a/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianNoteFormatterTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianNoteFormatterTest.kt
@@ -89,6 +89,40 @@ class ObsidianNoteFormatterTest {
     }
 
     @Test
+    fun customAppendPrefixSupportsWikiLinksBulletsAndEscapedNewlinesInBothModes() {
+        for (mode in listOf(ObsidianMode.MAIN_NOTE, ObsidianMode.NAMED_NOTE)) {
+            val cfg = config(mode, targetNote = "Inbox").copy(
+                appendPrefix = "- [[YYYY-MM-DD]] HH:mm:\\n\\n",
+            )
+            val write = ObsidianNoteFormatter.plan(cfg, "buy milk", y, mo, d, h, mi) as ObsidianWrite.Append
+            assertEquals("- [[2026-06-18]] 14:05:\n\nbuy milk\n", write.block)
+        }
+    }
+
+    @Test
+    fun prefixPreservesActualNewlinesAndSpacesWithoutExpandingNoteContent() {
+        val cfg = config(ObsidianMode.MAIN_NOTE).copy(appendPrefix = "[[YYYY-MM-DD]]\n- HH:mm: ")
+        val write = ObsidianNoteFormatter.plan(cfg, "Keep YYYY-MM-DD, HH:mm and \\n", y, mo, d, h, mi) as ObsidianWrite.Append
+        assertEquals("[[2026-06-18]]\n- 14:05: Keep YYYY-MM-DD, HH:mm and \\n\n", write.block)
+    }
+
+    @Test
+    fun emptyAppendPrefixWritesOnlyNoteText() {
+        val cfg = config(ObsidianMode.MAIN_NOTE).copy(appendPrefix = "")
+        val write = ObsidianNoteFormatter.plan(cfg, "buy milk", y, mo, d, h, mi) as ObsidianWrite.Append
+        assertEquals("buy milk\n", write.block)
+    }
+
+    @Test
+    fun appendPrefixDoesNotChangeTimestampedFiles() {
+        val cfg = config(ObsidianMode.TIMESTAMPED_FILES)
+        assertEquals(
+            ObsidianNoteFormatter.plan(cfg, "buy milk", y, mo, d, h, mi),
+            ObsidianNoteFormatter.plan(cfg.copy(appendPrefix = "- HH:mm: "), "buy milk", y, mo, d, h, mi),
+        )
+    }
+
+    @Test
     fun namedNoteKeepsExistingMdExtension() {
         val cfg = config(ObsidianMode.NAMED_NOTE, targetNote = "Daily.md")
         val write = ObsidianNoteFormatter.plan(cfg, "t", y, mo, d, h, mi) as ObsidianWrite.Append

--- a/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianPreferencesTest.kt
+++ b/experimental/src/commonTest/kotlin/coredevices/ring/agent/integrations/obsidian/ObsidianPreferencesTest.kt
@@ -17,6 +17,7 @@ class ObsidianPreferencesTest {
         assertEquals("", prefs.targetNote.value)
         assertEquals("Index Inbox", prefs.subfolder.value)
         assertEquals("", prefs.customTag.value)
+        assertEquals(ObsidianNoteFormatter.DEFAULT_APPEND_PREFIX, prefs.appendPrefix.value)
     }
 
     @Test
@@ -38,11 +39,21 @@ class ObsidianPreferencesTest {
         prefs.setSubfolder("Capture")
         prefs.setCustomTag("fleeting")
 
+        prefs.setAppendPrefix("- [[YYYY-MM-DD]] HH:mm: ")
+
         val reloaded = ObsidianPreferences(settings)
         assertEquals(ObsidianMode.NAMED_NOTE, reloaded.mode.value)
         assertEquals("Daily.md", reloaded.targetNote.value)
         assertEquals("Capture", reloaded.subfolder.value)
         assertEquals("fleeting", reloaded.customTag.value)
+        assertEquals("- [[YYYY-MM-DD]] HH:mm: ", reloaded.appendPrefix.value)
+    }
+
+    @Test
+    fun emptyAppendPrefixSurvivesReload() {
+        val settings = MapSettings()
+        ObsidianPreferences(settings).setAppendPrefix("")
+        assertEquals("", ObsidianPreferences(settings).appendPrefix.value)
     }
 
     @Test
@@ -52,13 +63,16 @@ class ObsidianPreferencesTest {
         prefs.setVault("h", "n")
         prefs.setMode(ObsidianMode.MAIN_NOTE)
         prefs.setCustomTag("fleeting")
+        prefs.setAppendPrefix("- ")
 
         prefs.clear()
 
         assertNull(prefs.vaultHandle.value)
         assertFalse(settings.hasKey("obsidian_vault_handle"))
         assertFalse(settings.hasKey("obsidian_custom_tag"))
+        assertFalse(settings.hasKey("obsidian_append_prefix"))
         assertEquals(ObsidianMode.TIMESTAMPED_FILES, prefs.mode.value)
         assertEquals("", prefs.customTag.value)
+        assertEquals(ObsidianNoteFormatter.DEFAULT_APPEND_PREFIX, prefs.appendPrefix.value)
     }
 }


### PR DESCRIPTION
## Make the prefix string to obsidian notes configurable

I love the simplicity of the Obsidian integration.
However, I kinda want to structure the file where the Index Agents writes to a bit differently.

Therefore, this PR enables the user to configure a string which prefixes whatever is inserted.
For example, it allows you to link your daily note so that you get backlinks to it.

Example:
`- [[YYYY-MM-DD]] HH:mm: ` produces `- [[2026-06-18]] 14:05: buy milk`

typed `\n` escapes and actual line breaks are supported. spaces, bullets, and Markdown are preserved.
The note text is added immediately after the prefix; an empty prefix writes only the note text.

code was AI generated, seems solid though. i entered the prompt and iterated a bit:

> in the app, there should be a config to configure the obsidian prefix string, eg i want to input:
[[YYYY-MM-DD]] HH:mm: and then this will be filled in. this can also include newlines: \n\n or leading bullets.
