### PR TITLE
index: fix stuck Index webhook transfer notifications for webhook transcript-only deliveries

### DIFF
--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexNotificationManager.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexNotificationManager.kt
@@ -134,6 +134,12 @@ class IndexNotificationManager(
             RingTransferStatus.Started, RingTransferStatus.Saving -> {
                 return InflightIndexNotification.Transferring(notifId, timestamp)
             }
+            // Webhook-only transcript deliveries intentionally create no recording entry or
+            // agent result. Once their audio has been saved, there is no local processing state
+            // left to show, so dismiss the transfer notification.
+            RingTransferStatus.Completed if entry == null -> {
+                return InflightIndexNotification.Discarded(notifId, timestamp)
+            }
             RingTransferStatus.Discarded -> {
                 return InflightIndexNotification.Discarded(notifId, timestamp)
             }

--- a/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexNotificationManager.kt
+++ b/experimental/src/commonMain/kotlin/coredevices/ring/service/IndexNotificationManager.kt
@@ -134,9 +134,6 @@ class IndexNotificationManager(
             RingTransferStatus.Started, RingTransferStatus.Saving -> {
                 return InflightIndexNotification.Transferring(notifId, timestamp)
             }
-            // Webhook-only transcript deliveries intentionally create no recording entry or
-            // agent result. Once their audio has been saved, there is no local processing state
-            // left to show, so dismiss the transfer notification.
             RingTransferStatus.Completed if entry == null -> {
                 return InflightIndexNotification.Discarded(notifId, timestamp)
             }


### PR DESCRIPTION
## Summary
- dismiss completed Index transfers that have no local recording entry
- prevents transcript-only webhook-only recordings from remaining as "Transferring recording" indefinitely

## Verification
- `git diff --check`
- attempted `./gradlew :experimental:compileKotlinAndroid`, but Gradle configuration cannot run in this workspace because `ANDROID_HOME` / `local.properties` is not configured

## AI disclosure
AI was used to investigate the notification state flow and draft this focused fix. I reviewed the resulting change and understand that webhook-only transcript delivery intentionally has no local recording entry; a completed transfer is therefore terminal for its local notification.