### PR TITLE
index: keep recoverable recordings queued

### DIFF
--- a/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
+++ b/experimental/src/androidDeviceTest/kotlin/coredevices/coreapp/ring/queue/RecordingProcessingQueueTest.kt
@@ -437,6 +437,35 @@ class RecordingProcessingQueueTest {
     }
 
     @Test
+    fun localAudioProcessing_transcriptionNetworkError_keepsRetryingUntilServiceReturns() = runBlocking {
+        val fileId = "test-audio-txn-prolonged-offline"
+        createFakeAudioFile(fileId)
+
+        fakeTranscription.enqueue(
+            FakeTranscriptionService.Behavior.NetworkError,
+            FakeTranscriptionService.Behavior.NetworkError,
+            FakeTranscriptionService.Behavior.NetworkError,
+            FakeTranscriptionService.Behavior.Success("Transcribed after reconnect")
+        )
+        fakeNenya.enqueue(
+            FakeNenyaClient.NenyaResponse.SuccessWithToolCalls,
+            FakeNenyaClient.NenyaResponse.SuccessFinal
+        )
+
+        queue.queueLocalAudioProcessing(fileId)
+        awaitTaskDone(taskId = 1)
+
+        val task = taskDao.getTaskById(1)!!
+        assertEquals(TaskStatus.Success, task.status)
+        assertEquals(4, task.attempts)
+
+        val entries = entryDao.getEntriesForRecording(1).first()
+        assertEquals(1, entries.size)
+        assertEquals(RecordingEntryStatus.completed, entries[0].status)
+        assertEquals("Transcribed after reconnect", entries[0].transcription)
+    }
+
+    @Test
     fun localAudioProcessing_transcriptionBusy_deferredThenSucceeds() = runBlocking {
         val fileId = "test-audio-txn-busy"
         createFakeAudioFile(fileId)

--- a/util/src/commonMain/kotlin/coredevices/util/queue/PersistentQueueScheduler.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/queue/PersistentQueueScheduler.kt
@@ -24,7 +24,6 @@ abstract class PersistentQueueScheduler<T : QueueTask>(
     private val scope: CoroutineScope,
     label: String,
     private val rescheduleDelay: Duration = 1.minutes,
-    private val maxAttempts: Int = 3,
     private val maxConcurrency: Int = 1,
 ): AutoCloseable {
     private val logger = Logger.withTag("Queue-$label")
@@ -42,11 +41,6 @@ abstract class PersistentQueueScheduler<T : QueueTask>(
                 val task = repository.getTaskById(id) ?: error("Task with id $id not found")
                 if (task.status != TaskStatus.Pending) {
                     logger.w { "Task with id $id is not pending (status: ${task.status}), skipping" }
-                    return@flow
-                }
-                if (task.attempts >= maxAttempts) {
-                    logger.e { "Task with id $id has reached max attempts ($maxAttempts), marking as failed" }
-                    repository.updateStatus(id, TaskStatus.Failed)
                     return@flow
                 }
                 repository.incrementAttempts(id)


### PR DESCRIPTION
## Summary

Keep recoverable Index recording-processing tasks pending until they succeed instead of permanently failing them after three attempts.

## Problem

I captured many Index 01 recordings while fishing in the Northwest Territories without internet access. The audio was preserved, but after the queue exhausted its three attempts, every recording had to be opened and retried manually after connectivity returned. That also prevented transcript-bearing webhooks from running automatically.

`RecoverableTaskException` already distinguishes transient network/model-busy failures from deterministic failures. Deterministic failures are immediately marked `Failed`, so the generic three-attempt cap only cuts off tasks explicitly classified as recoverable.

## Change

- Remove the three-attempt cap from `PersistentQueueScheduler`.
- Keep recoverable tasks in `Pending` so scheduled retries and app-start recovery can continue.
- Add a regression test covering three network failures followed by a successful fourth transcription.
- Verify that retrying reuses the original recording entry rather than creating a duplicate.

Once transcription succeeds, the existing `onTranscriptionPersisted` path delivers configured transcript-bearing webhooks.

## Testing

- `git diff --check`
- Added `localAudioProcessing_transcriptionNetworkError_keepsRetryingUntilServiceReturns`.
- I could not execute the Gradle test locally because the isolated environment could not download Gradle 9.6.1; CI should run it.

## AI disclosure

AI assistance was used to inspect the processing pipeline, identify the retry cutoff, implement the minimal patch, and draft this PR. I reviewed the resulting change and test.