### PR TITLE
Calendar: give reminders a Dismiss action so the watch offers its menu

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/CalendarEvent.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/calendar/CalendarEvent.kt
@@ -89,7 +89,14 @@ fun CalendarEvent.toTimelineReminder(timestamp: Instant, pinUuid: Uuid, vibePatt
             }
         }
         actions {
-            // TODO actions
+            // The watch's notification popup hides its action button entirely when an
+            // item carries no actions of its own (prv_should_provide_action_menu_for_item
+            // in notification_window.c), and the firmware only offers its own Snooze
+            // inside that menu. Without at least one action here, a calendar reminder
+            // buzzes but can be neither dismissed nor snoozed.
+            action(TimelineItem.Action.Type.Dismiss) {
+                attributes { title { DefaultTitles.DISMISS } }
+            }
         }
     }
 
@@ -108,6 +115,7 @@ object CalendarPinInternalType {
 /** Default English titles shown on the watch. Safe to localize without affecting dispatch. */
 private object DefaultTitles {
     const val ACCEPT = "Accept"
+    const val DISMISS = "Dismiss"
     const val MAYBE = "Maybe"
     const val DECLINE = "Decline"
     const val CANCEL = "Cancel"

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/timeline/TimelineActionManager.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/timeline/TimelineActionManager.kt
@@ -5,8 +5,10 @@ import io.rebble.libpebblecommon.SystemAppIDs.CALENDAR_APP_UUID
 import io.rebble.libpebblecommon.calendar.PlatformCalendarActionHandler
 import io.rebble.libpebblecommon.database.dao.TimelineNotificationRealDao
 import io.rebble.libpebblecommon.database.dao.TimelinePinRealDao
+import io.rebble.libpebblecommon.database.dao.TimelineReminderRealDao
 import io.rebble.libpebblecommon.database.entity.TimelineNotification
 import io.rebble.libpebblecommon.database.entity.TimelinePin
+import io.rebble.libpebblecommon.database.entity.TimelineReminder
 import io.rebble.libpebblecommon.di.ConnectionCoroutineScope
 import io.rebble.libpebblecommon.packets.blobdb.TimelineIcon
 import io.rebble.libpebblecommon.packets.blobdb.TimelineItem
@@ -34,6 +36,7 @@ class TimelineActionManager(
     private val notificationDao: TimelineNotificationRealDao,
     private val actionOverrides: ActionOverrides,
     private val pinDao: TimelinePinRealDao,
+    private val reminderDao: TimelineReminderRealDao,
 ) {
     companion object {
         private val logger = Logger.withTag(TimelineActionManager::class.simpleName!!)
@@ -70,6 +73,30 @@ class TimelineActionManager(
         }
     }
 
+    private suspend fun handleReminderAction(
+        reminder: TimelineReminder,
+        invocation: TimelineService.TimelineActionInvocation,
+    ): TimelineActionResult {
+        val action = reminder.content.actions.firstOrNull { it.actionID == invocation.actionId }
+            ?: run {
+                logger.w {
+                    "Action ${invocation.actionId} missing on reminder ${invocation.itemId}"
+                }
+                return failedResult()
+            }
+        return when (action.type) {
+            // The reminder popup's Dismiss (and the dismiss the firmware fires by
+            // itself after a snooze) is remote: the watch dismisses the popup on a
+            // successful response and there is nothing else for the phone to do.
+            TimelineItem.Action.Type.Dismiss -> TimelineActionResult(
+                success = true,
+                icon = TimelineIcon.ResultDismissed,
+                title = "Dismissed",
+            )
+            else -> failedResult()
+        }
+    }
+
     private suspend fun handleNotificationAction(
         notification: TimelineNotification,
         invocation: TimelineService.TimelineActionInvocation,
@@ -96,8 +123,11 @@ class TimelineActionManager(
             actionOverrides.actionHandlerOverrides[itemId]?.get(actionId)?.invoke(invocation.attributes)
                 ?: run {
                     val pin = pinDao.getEntry(itemId)
+                    val reminder = if (pin == null) reminderDao.getEntry(itemId) else null
                     if (pin != null) {
                         handlePinAction(pin, invocation)
+                    } else if (reminder != null) {
+                        handleReminderAction(reminder, invocation)
                     } else {
                         val notification = notificationDao.getEntry(itemId)
                         if (notification != null) {


### PR DESCRIPTION
Fixes #417.

## What

Calendar reminders buzz on the watch but their popup offers no menu: the firmware hides the popup's action button when an item carries no actions of its own (`prv_should_provide_action_menu_for_item()` in `notification_window.c`), and the firmware's own Snooze entry only ever appears inside that menu. So a calendar reminder can be neither dismissed nor snoozed — see #417 for the full analysis.

Two small changes:

1. **`CalendarEvent.toTimelineReminder()`**: every calendar reminder carries a Dismiss action (`TimelineItem.Action.Type.Dismiss`, title "Dismiss"), replacing the empty `actions { // TODO }` block. This makes the popup show its menu, with the firmware's Snooze beside the Dismiss.

2. **`TimelineActionManager`**: handle action invocations for reminders. It only looked items up in the pin and notification DAOs, so the Dismiss invocation — which the watch also fires by itself right after a snooze (`prv_snooze_reminder_cb`) — would come back "Failed". Dismiss on a reminder needs nothing beyond a successful response; the watch dismisses the popup itself. The reminder DAO's `getEntry` comes from the generated `TimelineReminderDao`, and `TimelineReminderRealDao` is already provided in the Koin module.

## Verification

- `:libpebble3:compileKotlinJvm` and `:libpebble3:jvmTest` pass (206 tests).
- The record-level fix was verified on hardware (Pebble Time 2, fw v4.37.0) in a separate companion-app implementation: the identical reminder record with no actions offers no menu; with one Dismiss action the menu opens, Snooze appears beside it, and snoozing re-buzzes after half the remaining time as `reminders.c` computes it.

## AI disclosure

Per CONTRIBUTING.md: this change was written with AI assistance (Claude). I directed the analysis (firmware source reading, hardware verification of the record-level behavior) and reviewed the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)