### PR TITLE
Add watch fast charging setting

### DIFF
--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/RoomTypeConverters.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/RoomTypeConverters.kt
@@ -182,7 +182,13 @@ class RoomTypeConverters {
 
     @TypeConverter
     fun StringToCapabilitySet(value: String): Set<ProtocolCapsFlag> {
-        return json.decodeFromString(value)
+        val known = ProtocolCapsFlag.entries.associateBy { it.name }
+        return json.decodeFromString<List<String>>(value).mapNotNull { name ->
+            known[name] ?: run {
+                logger.w { "Ignoring unknown watch capability: $name" }
+                null
+            }
+        }.toSet()
     }
 
     @TypeConverter

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/HealthSettings.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/HealthSettings.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlin.time.Clock
 import kotlin.time.Instant
-import kotlin.time.Instant.Companion.DISTANT_PAST
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -88,21 +87,8 @@ private val json = Json { ignoreUnknownKeys = true }
 // ActivityHRMSettings struct grew in firmware:
 //   v4.9.146: added uint8_t measurement_interval (1 → 2 bytes)
 //   v4.9.150: added bool activity_tracking_enabled  (2 → 3 bytes)
-private val FW_HRM_MEASUREMENT_INTERVAL = fwSentinel(4, 9, 146)
-private val FW_HRM_ACTIVITY_TRACKING = fwSentinel(4, 9, 150)
-
-private fun fwSentinel(major: Int, minor: Int, patch: Int) = FirmwareVersion(
-    stringVersion = "v$major.$minor.$patch",
-    timestamp = DISTANT_PAST,
-    major = major,
-    minor = minor,
-    patch = patch,
-    suffix = null,
-    gitHash = "",
-    isRecovery = false,
-    isDualSlot = false,
-    isSlot0 = false,
-)
+private val FW_HRM_MEASUREMENT_INTERVAL = FirmwareVersion.sentinel(4, 9, 146)
+private val FW_HRM_ACTIVITY_TRACKING = FirmwareVersion.sentinel(4, 9, 150)
 
 fun HealthSettingsEntryDao.getWatchSettings(): Flow<HealthSettings> {
     val activityPrefsFlow= getEntryFlow(KEY_ACTIVITY_PREFERENCES).map {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
@@ -16,6 +16,7 @@ import io.rebble.libpebblecommon.database.entity.QuickLaunchSetting.Companion.to
 import io.rebble.libpebblecommon.metadata.WatchType
 import io.rebble.libpebblecommon.packets.blobdb.TimelineAttribute
 import io.rebble.libpebblecommon.packets.blobdb.TimelineItem.Attribute
+import io.rebble.libpebblecommon.services.FirmwareVersion
 import io.rebble.libpebblecommon.services.blobdb.DbWrite
 import io.rebble.libpebblecommon.structmapper.SBoolean
 import io.rebble.libpebblecommon.structmapper.SFixedList
@@ -66,6 +67,11 @@ data class WatchPrefItem(
         val type = WatchPref.from(id)
         if (type == null) {
             logger.w { "Don't know how to encode watch pref key: $id" }
+            return null
+        }
+        val minFirmwareVersion = type.minFirmwareVersion
+        if (minFirmwareVersion != null && params.firmwareVersion < minFirmwareVersion) {
+            logger.d { "Watch firmware ${params.firmwareVersion.stringVersion} predates $id" }
             return null
         }
         logger.v { "trying to insert watch pref to watch blobdb: $id / $value" }
@@ -176,6 +182,7 @@ sealed interface WatchPref<T> {
     fun encodeValue(value: T): String
     fun castParent(parent: WatchPreference<*>): WatchPreference<T> = parent as WatchPreference<T>
     val isDebugSetting: Boolean
+    val minFirmwareVersion: FirmwareVersion? get() = null
 
     companion object {
         fun enumeratePrefs(): List<WatchPref<*>> = BoolWatchPref.entries
@@ -407,6 +414,21 @@ enum class WatchLanguage(override val code: UByte, override val displayName: Str
     Polish(9u, "Polski"),
 }
 
+// Matches CHARGE_LIMIT_PCT_* in pebble-firmware:include/pbl/services/battery/battery_charge_limit.h.
+enum class ChargeLimitLevel(override val code: UByte, override val displayName: String) : WatchPrefEnum {
+    Off(0u, "Off"),
+    Limit50(50u, "50%"),
+    Limit55(55u, "55%"),
+    Limit60(60u, "60%"),
+    Limit65(65u, "65%"),
+    Limit70(70u, "70%"),
+    Limit75(75u, "75%"),
+    Limit80(80u, "80%"),
+    Limit85(85u, "85%"),
+    Limit90(90u, "90%"),
+    Limit95(95u, "95%"),
+}
+
 enum class EnumWatchPref(
     override val id: String,
     override val displayName: String,
@@ -414,6 +436,7 @@ enum class EnumWatchPref(
     val options: List<WatchPrefEnum>,
     override val isDebugSetting: Boolean = false,
     override val description: String? = null,
+    override val minFirmwareVersion: FirmwareVersion? = null,
 ) : WatchPref<WatchPrefEnum> {
     TextSize("textStyle", "Text Size", ContentSize.Default, ContentSize.entries),
     NotificationFilter(
@@ -534,6 +557,23 @@ enum class EnumWatchPref(
         defaultValue = WatchLanguage.Custom,
         options = WatchLanguage.entries,
     ),
+    ChargeLimit(
+        id = "chargeLimitPct",
+        displayName = "Charge Limit",
+        description = "Limit charging to extend your battery's lifespan",
+        defaultValue = ChargeLimitLevel.Off,
+        options = ChargeLimitLevel.entries,
+        minFirmwareVersion = FirmwareVersion.sentinel(4, 37, 0),
+    ) {
+        override fun decodeValue(value: String): WatchPrefEnum {
+            val code = value.toUByteOrNull() ?: return defaultValue
+            if (code > ChargeLimitLevel.Limit95.code) return ChargeLimitLevel.Off
+            return ChargeLimitLevel.entries
+                .filter { it != ChargeLimitLevel.Off && it.code <= code }
+                .maxByOrNull { it.code }
+                ?: ChargeLimitLevel.Off
+        }
+    },
     ;
 
     override val type = WatchPrefType.TypeUInt8

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/WatchPrefEntity.kt
@@ -202,6 +202,7 @@ enum class BoolWatchPref(
     override val defaultValue: Boolean,
     override val isDebugSetting: Boolean = false,
     override val description: String? = null,
+    override val minFirmwareVersion: FirmwareVersion? = null,
 ) : WatchPref<Boolean> {
     TimezoneSourceIsManual("timezoneSource", "Timezone configured manually", false, description = "Manually configure a time zone on the watch (instead of automatcially using the time zone of the phone)"),
     Clock24h("clock24h", "24h clock", false),
@@ -222,6 +223,13 @@ enum class BoolWatchPref(
     MusicShowVolumeControls("musicShowVolumeControls", "Show Volume Controls", true),
     MusicShowProgressBar("musicShowProgressBar", "Show Progress Bar", true),
     MusicShowAlbumArt("musicShowAlbumArt", "Show Album Art", false),
+    FastCharge(
+        "fastCharge",
+        "Fast Charging",
+        true,
+        description = "Turn off for gentler charging (Pebble Time 2 only)",
+        minFirmwareVersion = FirmwareVersion.sentinel(4, 37, 0),
+    ),
     ;
 
     override val type = WatchPrefType.TypeBoolean

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/SystemService.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/services/SystemService.kt
@@ -323,6 +323,19 @@ data class FirmwareVersion(
             )
         }
 
+        fun sentinel(major: Int, minor: Int, patch: Int) = FirmwareVersion(
+            stringVersion = "v$major.$minor.$patch",
+            timestamp = Instant.DISTANT_PAST,
+            major = major,
+            minor = minor,
+            patch = patch,
+            suffix = null,
+            gitHash = "",
+            isRecovery = false,
+            isDualSlot = false,
+            isSlot0 = false,
+        )
+
         fun FirmwareVersion.slot(): Int? = when {
             isDualSlot && isSlot0 -> 0
             isDualSlot && !isSlot0 -> 1

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/RoomTypeConvertersTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/RoomTypeConvertersTest.kt
@@ -1,0 +1,31 @@
+package io.rebble.libpebblecommon.database
+
+import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoomTypeConvertersTest {
+    private val converters = RoomTypeConverters()
+
+    @Test
+    fun capabilitySetRoundTrips() {
+        val capabilities = setOf(
+            ProtocolCapsFlag.SupportsAppRunStateProtocol,
+            ProtocolCapsFlag.SupportsWeatherApp,
+        )
+        assertEquals(
+            capabilities,
+            converters.StringToCapabilitySet(converters.CapabilitySetToString(capabilities)),
+        )
+    }
+
+    @Test
+    fun capabilitySetIgnoresUnknownNames() {
+        assertEquals(
+            setOf(ProtocolCapsFlag.SupportsWeatherApp),
+            converters.StringToCapabilitySet(
+                """["SupportsWeatherApp","SupportsSomethingFromTheFuture"]"""
+            ),
+        )
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitPrefTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitPrefTest.kt
@@ -1,0 +1,55 @@
+package io.rebble.libpebblecommon.database.entity
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChargeLimitPrefTest {
+    @Test
+    fun prefIdMatchesTheFirmwareSettingsKey() {
+        assertEquals("chargeLimitPct", EnumWatchPref.ChargeLimit.id)
+    }
+
+    @Test
+    fun decodesExactCodes() {
+        assertEquals(ChargeLimitLevel.Limit80, EnumWatchPref.ChargeLimit.decodeValue("80"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("0"))
+    }
+
+    @Test
+    fun decodesTheFirmwareRangeBoundaries() {
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("49"))
+        assertEquals(ChargeLimitLevel.Limit50, EnumWatchPref.ChargeLimit.decodeValue("50"))
+        assertEquals(ChargeLimitLevel.Limit95, EnumWatchPref.ChargeLimit.decodeValue("95"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("96"))
+    }
+
+    @Test
+    fun snapsOffStepValuesToTheStepBelow() {
+        assertEquals(ChargeLimitLevel.Limit80, EnumWatchPref.ChargeLimit.decodeValue("82"))
+        assertEquals(ChargeLimitLevel.Limit50, EnumWatchPref.ChargeLimit.decodeValue("54"))
+        assertEquals(ChargeLimitLevel.Limit90, EnumWatchPref.ChargeLimit.decodeValue("94"))
+    }
+
+    @Test
+    fun fallsBackToOffForValuesTheFirmwareRejects() {
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("30"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("96"))
+        assertEquals(ChargeLimitLevel.Off, EnumWatchPref.ChargeLimit.decodeValue("garbage"))
+    }
+
+    @Test
+    fun encodesTheRawPercentCode() {
+        assertEquals("80", EnumWatchPref.ChargeLimit.encodeValue(ChargeLimitLevel.Limit80))
+        assertEquals("0", EnumWatchPref.ChargeLimit.encodeValue(ChargeLimitLevel.Off))
+    }
+
+    @Test
+    fun encodeDecodeRoundTripsEveryLevel() {
+        ChargeLimitLevel.entries.forEach { level ->
+            assertEquals(
+                level,
+                EnumWatchPref.ChargeLimit.decodeValue(EnumWatchPref.ChargeLimit.encodeValue(level))
+            )
+        }
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/FastChargePrefTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/entity/FastChargePrefTest.kt
@@ -1,0 +1,24 @@
+package io.rebble.libpebblecommon.database.entity
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FastChargePrefTest {
+    @Test
+    fun prefIdMatchesTheFirmwareSettingsKey() {
+        assertEquals("fastCharge", BoolWatchPref.FastCharge.id)
+    }
+
+    @Test
+    fun defaultsToFastCharging() {
+        assertTrue(BoolWatchPref.FastCharge.defaultValue)
+    }
+
+    @Test
+    fun encodesAsAFirmwareBoolean() {
+        assertEquals("1", BoolWatchPref.FastCharge.encodeValue(true))
+        assertEquals("0", BoolWatchPref.FastCharge.encodeValue(false))
+        assertEquals(false, BoolWatchPref.FastCharge.decodeValue("0"))
+    }
+}

--- a/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitValueTest.kt
+++ b/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/ChargeLimitValueTest.kt
@@ -1,0 +1,71 @@
+package io.rebble.libpebblecommon.database.entity
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.database.asMillisecond
+import io.rebble.libpebblecommon.database.dao.ValueParams
+import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+private fun firmware(major: Int, minor: Int, patch: Int, suffix: String? = null) = FirmwareVersion(
+    stringVersion = "v$major.$minor.$patch" + (suffix?.let { "-$it" } ?: ""),
+    timestamp = Instant.fromEpochSeconds(1_757_000_000),
+    major = major,
+    minor = minor,
+    patch = patch,
+    suffix = suffix,
+    gitHash = "abc1234",
+    isRecovery = false,
+    isDualSlot = true,
+    isSlot0 = false,
+)
+
+class ChargeLimitValueTest {
+    private val item = WatchPrefItem(
+        id = EnumWatchPref.ChargeLimit.id,
+        value = "80",
+        timestamp = Instant.DISTANT_PAST.asMillisecond(),
+    )
+
+    private fun params(firmwareVersion: FirmwareVersion) = ValueParams(
+        WatchType.APLITE,
+        emptySet(),
+        firmwareVersion,
+        libPebbleConfigFlow = LibPebbleConfigFlow(MutableStateFlow(LibPebbleConfig())),
+    )
+
+    @Test
+    fun encodesOnTheFirstFirmwareThatShipsThePref() {
+        assertContentEquals(ubyteArrayOf(80u), item.value(params(firmware(4, 37, 0))))
+    }
+
+    @Test
+    fun encodesOnDevelopmentBuildsPastThatTag() {
+        assertContentEquals(ubyteArrayOf(80u), item.value(params(firmware(4, 37, 0, "9-gabc1234"))))
+    }
+
+    @Test
+    fun encodesOnLaterFirmware() {
+        assertContentEquals(ubyteArrayOf(80u), item.value(params(firmware(4, 38, 0))))
+    }
+
+    @Test
+    fun skippedOnFirmwareThatPredatesThePref() {
+        assertNull(item.value(params(firmware(4, 36, 2))))
+    }
+
+    @Test
+    fun prefsWithoutAMinimumVersionAreUnaffected() {
+        val clock24h = WatchPrefItem(
+            id = BoolWatchPref.Clock24h.id,
+            value = "1",
+            timestamp = Instant.DISTANT_PAST.asMillisecond(),
+        )
+        assertContentEquals(ubyteArrayOf(1u), clock24h.value(params(firmware(4, 0, 0))))
+    }
+}

--- a/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/FastChargeValueTest.kt
+++ b/libpebble3/src/jvmTest/kotlin/io/rebble/libpebblecommon/database/entity/FastChargeValueTest.kt
@@ -1,0 +1,51 @@
+package io.rebble.libpebblecommon.database.entity
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.database.asMillisecond
+import io.rebble.libpebblecommon.database.dao.ValueParams
+import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+private fun firmware(major: Int, minor: Int, patch: Int) = FirmwareVersion(
+    stringVersion = "v$major.$minor.$patch",
+    timestamp = Instant.fromEpochSeconds(1_757_000_000),
+    major = major,
+    minor = minor,
+    patch = patch,
+    suffix = null,
+    gitHash = "abc1234",
+    isRecovery = false,
+    isDualSlot = true,
+    isSlot0 = false,
+)
+
+class FastChargeValueTest {
+    private val item = WatchPrefItem(
+        id = BoolWatchPref.FastCharge.id,
+        value = "0",
+        timestamp = Instant.DISTANT_PAST.asMillisecond(),
+    )
+
+    private fun params(firmwareVersion: FirmwareVersion) = ValueParams(
+        WatchType.APLITE,
+        emptySet(),
+        firmwareVersion,
+        libPebbleConfigFlow = LibPebbleConfigFlow(MutableStateFlow(LibPebbleConfig())),
+    )
+
+    @Test
+    fun encodesOnFirmwareThatShipsThePref() {
+        assertContentEquals(ubyteArrayOf(0u), item.value(params(firmware(4, 37, 0))))
+    }
+
+    @Test
+    fun skippedOnFirmwareThatPredatesThePref() {
+        assertNull(item.value(params(firmware(4, 36, 2))))
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/BatterySettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/BatterySettingsScreen.kt
@@ -47,6 +47,20 @@ private const val MOBILE_BATTERY_PATH = "/m/battery"
 
 @Composable
 fun BatterySettingsScreen(navBarNav: NavBarNav, topBarParams: TopBarParams) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        chargeLimitSettingsItem()?.Item()
+        Box(Modifier.weight(1f)) {
+            BatteryAnalyticsContent(navBarNav, topBarParams)
+        }
+    }
+}
+
+@Composable
+private fun BatteryAnalyticsContent(navBarNav: NavBarNav, topBarParams: TopBarParams) {
     val apiConfig = koinInject<CommonApiConfig>()
     val settings = koinInject<Settings>()
     val analyticsEnabled = settings.getBoolean(KEY_ENABLE_MEMFAULT_UPLOADS, true)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/BatterySettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/BatterySettingsScreen.kt
@@ -52,7 +52,7 @@ fun BatterySettingsScreen(navBarNav: NavBarNav, topBarParams: TopBarParams) {
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background),
     ) {
-        chargeLimitSettingsItem()?.Item()
+        batteryPrefItems().forEach { it.Item() }
         Box(Modifier.weight(1f)) {
             BatteryAnalyticsContent(navBarNav, topBarParams)
         }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -23,7 +23,9 @@ import io.rebble.libpebblecommon.SystemAppIDs.MOTION_BACKLIGHT_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.QUIET_TIME_TOGGLE_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.TIMELINE_FUTURE_UUID
 import io.rebble.libpebblecommon.SystemAppIDs.TIMELINE_PAST_UUID
+import io.rebble.libpebblecommon.connection.KnownPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.connection.PebbleDevice
 import io.rebble.libpebblecommon.database.dao.WatchPreference
 import io.rebble.libpebblecommon.database.entity.BacklightPresetMode
 import io.rebble.libpebblecommon.database.entity.BoolWatchPref
@@ -36,8 +38,10 @@ import io.rebble.libpebblecommon.database.entity.RgbColorWatchPref
 import io.rebble.libpebblecommon.database.entity.WatchPref
 import io.rebble.libpebblecommon.database.entity.WatchPrefEnum
 import io.rebble.libpebblecommon.locker.AppType
+import io.rebble.libpebblecommon.services.FirmwareVersion
 import io.rebble.libpebblecommon.timeline.TimelineColor
 import kotlinx.coroutines.flow.map
+import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
 // Snap the notification timeout slider to 30-second increments (20 stops across 0..600s)
@@ -66,8 +70,10 @@ fun watchPrefs(): List<SettingsItem> {
     val libPebble = rememberLibPebble()
     val settings by libPebble.watchPrefs.collectAsState(emptyList())
     val quickLaunchOptions = quickLaunchOptions(libPebble)
-    val mapped = remember(settings, quickLaunchOptions) {
-        settings.hidePresetManagedBacklightPrefs().map { item ->
+    val watches by libPebble.watches.collectAsState()
+    val firmwareVersions = remember(watches) { watches.knownFirmwareVersions() }
+    val mapped = remember(settings, quickLaunchOptions, firmwareVersions) {
+        settings.hidePresetManagedBacklightPrefs().filter { firmwareVersions.anySupports(it.pref) }.map { item ->
             when (val pref = item.pref) {
                 is BoolWatchPref -> booleanPref(pref.castParent(item), libPebble)
                 is EnumWatchPref -> enumPref(pref.castParent(item), libPebble)
@@ -157,6 +163,21 @@ fun WatchPref<*>.section(): Section = when (this) {
     BoolWatchPref.MusicShowVolumeControls -> Section.Music
     BoolWatchPref.MusicShowProgressBar -> Section.Music
     BoolWatchPref.MusicShowAlbumArt -> Section.Music
+    EnumWatchPref.ChargeLimit -> Section.Battery
+}
+
+@Composable
+internal fun chargeLimitSettingsItem(): SettingsItem? {
+    val libPebble = rememberLibPebble()
+    val config by libPebble.config.collectAsState()
+    val watches by libPebble.watches.collectAsState()
+    val firmwareVersions = remember(watches) { watches.knownFirmwareVersions() }
+    if (!config.watchConfig.enableWatchSettingsSync || !firmwareVersions.anySupports(EnumWatchPref.ChargeLimit)) {
+        return null
+    }
+    val settings by libPebble.watchPrefs.collectAsState(emptyList())
+    val item = settings.firstOrNull { it.pref == EnumWatchPref.ChargeLimit } ?: return null
+    return enumPref(EnumWatchPref.ChargeLimit.castParent(item), libPebble, controlOnLeft = true)
 }
 
 fun WatchPref<*>.topLevelType(): TopLevelType = when (this) {
@@ -164,6 +185,23 @@ fun WatchPref<*>.topLevelType(): TopLevelType = when (this) {
     EnumWatchPref.WindSpeed -> TopLevelType.Phone
     else -> TopLevelType.Watch
 }
+
+internal fun List<PebbleDevice>.knownFirmwareVersions(): Set<FirmwareVersion> =
+    filterIsInstance<KnownPebbleDevice>().mapNotNull { it.firmwareVersion() }.toSet()
+
+internal fun Set<FirmwareVersion>.anySupports(pref: WatchPref<*>): Boolean {
+    val minFirmwareVersion = pref.minFirmwareVersion ?: return true
+    return any { it >= minFirmwareVersion }
+}
+
+private fun KnownPebbleDevice.firmwareVersion(): FirmwareVersion? = FirmwareVersion.from(
+    tag = runningFwVersion,
+    isRecovery = false,
+    gitHash = "",
+    timestamp = Instant.DISTANT_PAST,
+    isDualSlot = false,
+    isSlot0 = false,
+)
 
 private fun numberPref(item: WatchPreference<Long>, libPebble: LibPebble): SettingsItem {
     val pref = item.pref as NumberWatchPref
@@ -281,7 +319,11 @@ private fun booleanPref(item: WatchPreference<Boolean>, libPebble: LibPebble): S
     )
 }
 
-private fun enumPref(item: WatchPreference<WatchPrefEnum>, libPebble: LibPebble): SettingsItem {
+private fun enumPref(
+    item: WatchPreference<WatchPrefEnum>,
+    libPebble: LibPebble,
+    controlOnLeft: Boolean = false,
+): SettingsItem {
     val pref = item.pref as EnumWatchPref
     return basicSettingsDropdownItem(
         id = pref.id,
@@ -296,6 +338,7 @@ private fun enumPref(item: WatchPreference<WatchPrefEnum>, libPebble: LibPebble)
         },
         itemText = { it.displayName },
         isDebugSetting = pref.isDebugSetting,
+        controlOnLeft = controlOnLeft,
     )
 }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchPrefsScreen.kt
@@ -73,16 +73,9 @@ fun watchPrefs(): List<SettingsItem> {
     val watches by libPebble.watches.collectAsState()
     val firmwareVersions = remember(watches) { watches.knownFirmwareVersions() }
     val mapped = remember(settings, quickLaunchOptions, firmwareVersions) {
-        settings.hidePresetManagedBacklightPrefs().filter { firmwareVersions.anySupports(it.pref) }.map { item ->
-            when (val pref = item.pref) {
-                is BoolWatchPref -> booleanPref(pref.castParent(item), libPebble)
-                is EnumWatchPref -> enumPref(pref.castParent(item), libPebble)
-                is QuicklaunchWatchPref -> quicklaunchPref(pref.castParent(item), libPebble, quickLaunchOptions)
-                is ColorWatchPref -> colorPref(pref.castParent(item), libPebble)
-                is RgbColorWatchPref -> rgbColorPref(pref.castParent(item), libPebble)
-                is NumberWatchPref -> numberPref(pref.castParent(item), libPebble)
-            }
-        }
+        settings.hidePresetManagedBacklightPrefs()
+            .filter { firmwareVersions.anySupports(it.pref) }
+            .map { it.settingsItem(libPebble, quickLaunchOptions) }
     }
     val showConfirmReset = remember { mutableStateOf(false) }
     ConfirmDialog(
@@ -164,20 +157,38 @@ fun WatchPref<*>.section(): Section = when (this) {
     BoolWatchPref.MusicShowProgressBar -> Section.Music
     BoolWatchPref.MusicShowAlbumArt -> Section.Music
     EnumWatchPref.ChargeLimit -> Section.Battery
+    BoolWatchPref.FastCharge -> Section.Battery
 }
 
 @Composable
-internal fun chargeLimitSettingsItem(): SettingsItem? {
+internal fun batteryPrefItems(): List<SettingsItem> {
     val libPebble = rememberLibPebble()
     val config by libPebble.config.collectAsState()
     val watches by libPebble.watches.collectAsState()
     val firmwareVersions = remember(watches) { watches.knownFirmwareVersions() }
-    if (!config.watchConfig.enableWatchSettingsSync || !firmwareVersions.anySupports(EnumWatchPref.ChargeLimit)) {
-        return null
+    if (!config.watchConfig.enableWatchSettingsSync) {
+        return emptyList()
     }
     val settings by libPebble.watchPrefs.collectAsState(emptyList())
-    val item = settings.firstOrNull { it.pref == EnumWatchPref.ChargeLimit } ?: return null
-    return enumPref(EnumWatchPref.ChargeLimit.castParent(item), libPebble, controlOnLeft = true)
+    return BATTERY_PREFS
+        .mapNotNull { pref -> settings.firstOrNull { it.pref == pref } }
+        .filter { firmwareVersions.anySupports(it.pref) }
+        .map { it.settingsItem(libPebble, quickLaunchOptions = emptyList(), controlOnLeft = true) }
+}
+
+private val BATTERY_PREFS: List<WatchPref<*>> = listOf(EnumWatchPref.ChargeLimit, BoolWatchPref.FastCharge)
+
+private fun WatchPreference<*>.settingsItem(
+    libPebble: LibPebble,
+    quickLaunchOptions: List<QuickLaunchOption>,
+    controlOnLeft: Boolean = false,
+): SettingsItem = when (val pref = pref) {
+    is BoolWatchPref -> booleanPref(pref.castParent(this), libPebble)
+    is EnumWatchPref -> enumPref(pref.castParent(this), libPebble, controlOnLeft)
+    is QuicklaunchWatchPref -> quicklaunchPref(pref.castParent(this), libPebble, quickLaunchOptions)
+    is ColorWatchPref -> colorPref(pref.castParent(this), libPebble)
+    is RgbColorWatchPref -> rgbColorPref(pref.castParent(this), libPebble)
+    is NumberWatchPref -> numberPref(pref.castParent(this), libPebble)
 }
 
 fun WatchPref<*>.topLevelType(): TopLevelType = when (this) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Slider
@@ -2665,6 +2666,8 @@ fun basicSettingsNumberFieldItem(
     },
 )
 
+private val LEADING_CONTROL_WIDTH = 48.dp
+
 fun <T> basicSettingsDropdownItem(
     id: String? = null,
     title: String,
@@ -2679,6 +2682,7 @@ fun <T> basicSettingsDropdownItem(
     show: () -> Boolean = { true },
     isDebugSetting: Boolean = false,
     extraSupportingContent: (@Composable () -> Unit)? = null,
+    controlOnLeft: Boolean = false,
 ) = SettingsItem(
     id = id,
     title = title,
@@ -2688,36 +2692,44 @@ fun <T> basicSettingsDropdownItem(
     show = show,
     isDebugSetting = isDebugSetting,
     item = {
+        val dropdown: @Composable () -> Unit = {
+            var expanded by remember { mutableStateOf(false) }
+            Box(
+                modifier = if (controlOnLeft) Modifier.width(LEADING_CONTROL_WIDTH) else Modifier,
+                contentAlignment = Alignment.Center,
+            ) {
+                TextButton(
+                    onClick = { expanded = true },
+                    contentPadding = if (controlOnLeft) PaddingValues(0.dp) else ButtonDefaults.TextButtonContentPadding,
+                ) {
+                    Text(
+                        text = itemText(selectedItem),
+                        modifier = Modifier.widthIn(max = 150.dp),
+                        maxLines = 1,
+                    )
+                }
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    items.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(itemText(option)) },
+                            onClick = {
+                                onItemSelected(option)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
         ListItem(
             headlineContent = {
                 Text(title)
             },
-            trailingContent = {
-                var expanded by remember { mutableStateOf(false) }
-                Box {
-                    TextButton(onClick = { expanded = true }) {
-                        Text(
-                            text = itemText(selectedItem),
-                            modifier = Modifier.widthIn(max = 150.dp),
-                            maxLines = 1,
-                        )
-                    }
-                    DropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false }
-                    ) {
-                        items.forEach { option ->
-                            DropdownMenuItem(
-                                text = { Text(itemText(option)) },
-                                onClick = {
-                                    onItemSelected(option)
-                                    expanded = false
-                                }
-                            )
-                        }
-                    }
-                }
-            },
+            leadingContent = if (controlOnLeft) dropdown else null,
+            trailingContent = if (controlOnLeft) null else dropdown,
             supportingContent = {
                 Row {
                     if (description != null) {


### PR DESCRIPTION
# Add watch fast charging setting

Adds a Fast Charging toggle to the Battery screen, backed by the `fastCharge` watch pref from coredevices/PebbleOS#2052. It is on by default, matching the firmware, so nothing changes until someone turns it off to charge at the gentler standard rate.

| Light | Dark |
| --- | --- |
| ![Battery screen in light mode](https://github.com/peblum/mobileapp/releases/download/pr-assets/charge-limit-light.png) | ![Battery screen in dark mode](https://github.com/peblum/mobileapp/releases/download/pr-assets/charge-limit-dark.png) |

> [!NOTE]
> Stacked on #318, which adds the Battery screen's watch pref rendering, the leading-slot row layout and the per-pref `minFirmwareVersion` gate this reuses. Only the last commit is new.

The Battery screen renders every watch pref in its section from an explicit ordered list rather than one hard-coded item, through the same mapping the watch settings list uses, so a further battery pref is a one-line addition. `BoolWatchPref` gains the `minFirmwareVersion` parameter `EnumWatchPref` already had, and the toggle is pinned to `v4.37.0` for the same reason as the charge limit: it should move to the release that ships the firmware change once known. `FastChargePrefTest` and `FastChargeValueTest` cover the key, the default, the encoding and the version gate.

Written with AI assistance (Claude), and exercised on a Pixel 6 with a Pebble Time 2.

---

Aside: I am currently available for mobile or firmware contracting or full-time work. Contact: adrian@pascu.be.
